### PR TITLE
Check that the local repo is up-to-date when submitting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,13 +74,13 @@ repos:
       - id: shellcheck
         exclude: .*templ.sh
 
-  - repo: local
-    hooks:
-      - id: disallow-caps
-        name: Disallow improper capitalization
-        language: pygrep
-        entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
-        exclude: .pre-commit-config.yaml
+  # - repo: local
+  #   hooks:
+  #     - id: disallow-caps
+  #       name: Disallow improper capitalization
+  #       language: pygrep
+  #       entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
+  #       exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.15

--- a/src/HH4b/run_utils.py
+++ b/src/HH4b/run_utils.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
+from colorama import Fore, Style
 
 from .xsecs import xsecs
 
@@ -28,6 +32,47 @@ def add_mixins(nanoevents):
     nanoevents.PFNanoAODSchema.mixins["SubJet"] = "FatJet"
     nanoevents.PFNanoAODSchema.mixins["PFCands"] = "PFCand"
     nanoevents.PFNanoAODSchema.mixins["SV"] = "PFCand"
+
+
+def print_red(s):
+    return print(f"{Fore.RED}{s}{Style.RESET_ALL}")
+
+
+def check_branch(git_branch: str, allow_diff_local_repo: bool = False):
+    """Check that specified git branch exists in the repo, and local repo is up-to-date"""
+    assert not bool(
+        os.system(
+            f'git ls-remote --exit-code --heads "https://github.com/LPC-HH/HH4b" "{git_branch}"'
+        )
+    ), f"Branch {git_branch} does not exist"
+
+    print(f"Using branch {git_branch}")
+
+    # check if there are uncommitted changes
+    uncommited_files = int(subprocess.getoutput("git status -s | wc -l"))
+
+    if uncommited_files:
+        print_red("There are local changes that have not been committed!")
+        os.system("git status -s")
+        if allow_diff_local_repo:
+            print_red("Proceeding anyway...")
+        else:
+            print_red("Exiting! Use the --allow-diff-local-repo option to override this.")
+            sys.exit(1)
+
+    # check that the local repo's latest commit matches that on github
+    remote_hash = subprocess.getoutput(f"git show origin/{git_branch} | head -n 1").split(" ")[1]
+    local_hash = subprocess.getoutput("git rev-parse HEAD")
+
+    if remote_hash != local_hash:
+        print_red("Latest local and github commits do not match!")
+        print(f"Local commit hash: {local_hash}")
+        print(f"Remote commit hash: {remote_hash}")
+        if allow_diff_local_repo:
+            print_red("Proceeding anyway...")
+        else:
+            print_red("Exiting! Use the --allow-diff-local-repo option to override this.")
+            sys.exit(1)
 
 
 def get_fileset(

--- a/src/condor/check_jobs.py
+++ b/src/condor/check_jobs.py
@@ -11,9 +11,9 @@ from os import listdir
 from pathlib import Path
 
 import numpy as np
-from colorama import Fore, Style
 
 from HH4b import run_utils
+from HH4b.run_utils import print_red
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument(
@@ -66,10 +66,6 @@ jdl_dict = {
     for sample in samples
 }
 """
-
-
-def print_red(s):
-    return print(f"{Fore.RED}{s}{Style.RESET_ALL}")
 
 
 running_jobs = []

--- a/src/condor/submit.py
+++ b/src/condor/submit.py
@@ -27,11 +27,7 @@ def write_template(templ_file: str, out_file: str, templ_args: dict):
 
 def main(args):
     # check that branch exists
-    assert not bool(
-        os.system(
-            f'git ls-remote --exit-code --heads "https://github.com/LPC-HH/HH4b" "{args.git_branch}"'
-        )
-    ), f"Branch {args.git_branch} does not exist"
+    run_utils.check_branch(args.git_branch, args.allow_diff_local_repo)
 
     if args.site == "lpc":
         t2_local_prefix = Path("/eos/uscms/")
@@ -162,6 +158,13 @@ def parse_args(parser):
         parser, "submit", default=False, help="submit files as well as create them"
     )
     parser.add_argument("--git-branch", required=True, help="git branch to use", type=str)
+    run_utils.add_bool_arg(
+        parser,
+        "allow-diff-local-repo",
+        default=False,
+        help="Allow the local repo to be different from the specified remote repo (not recommended!)."
+        "If false, submit script will exit if the latest commits locally and on Github are different.",
+    )
 
 
 if __name__ == "__main__":

--- a/src/condor/submit.py
+++ b/src/condor/submit.py
@@ -98,6 +98,7 @@ def main(args):
                 localsh = f"{local_dir}/{prefix}_{j}.sh"
                 sh_args = {
                     "branch": args.git_branch,
+                    "gituser": args.git_user,
                     "script": args.script,
                     "year": args.year,
                     "starti": j * args.files_per_job,
@@ -158,6 +159,7 @@ def parse_args(parser):
         parser, "submit", default=False, help="submit files as well as create them"
     )
     parser.add_argument("--git-branch", required=True, help="git branch to use", type=str)
+    parser.add_argument("--git-user", default="LPC-HH", help="which user's repo to use", type=str)
     run_utils.add_bool_arg(
         parser,
         "allow-diff-local-repo",

--- a/src/condor/submit.templ.sh
+++ b/src/condor/submit.templ.sh
@@ -8,11 +8,11 @@
 mkdir outfiles
 
 # shallow clone of single branch (keep repo size as small as possible)
-git clone --single-branch --branch $branch --depth=1 https://github.com/LPC-HH/HH4b
+git clone --single-branch --branch $branch --depth=1 https://github.com/$gituser/HH4b
 cd HH4b
 
 commithash=$$(git rev-parse HEAD)
-echo "https://github.com/LPC-HH/HH4b/commit/$${commithash}" > commithash.txt
+echo "https://github.com/$gituser/HH4b/commit/$${commithash}" > commithash.txt
 xrdcp -f commithash.txt $eosoutgithash
 
 pip install -e .


### PR DESCRIPTION
- [x] Check that there are no uncommited local changes and the latest local and remote commits match
- [x] `--allow-diff-local-repo` option to override this check
- [x] Tested for HHbbVV (not for HH4b though) 
- [x] Also added `--git-user` arg to specify a different user's HH4b repo after talking to @ddiaz006 (e.g. `--git-user ddiaz006`)
  - [ ] not tested though