### PR TITLE
Add missing signal samples and few fixes to Postprocess.py

### DIFF
--- a/src/HH4b/hh_vars.py
+++ b/src/HH4b/hh_vars.py
@@ -29,21 +29,20 @@ DATA_SAMPLES = ["JetMET", "Muon", "EGamma"]
 # sample key -> list of samples or selectors
 common_samples_bg = {
     "qcd": ["QCD_HT"],
-    # "qcd": ["QCD_PT"],
     "data": [f"{key}_Run" for key in DATA_SAMPLES],
     "ttbar": ["TTto4Q", "TTto2L2Nu", "TTtoLNu2Q"],
-    # "ttlep": ["TTto2L2Nu", "TTtoLNu2Q"],
     "gghtobb": ["GluGluHto2B_PT-200_M-125"],
     "vbfhtobb": ["VBFHto2B_M-125_dipoleRecoilOn"],
+    # TODO: Add single top!
     "vhtobb": [
         "WplusH_Hto2B_Wto2Q_M-125",
-        # "WplusH_Hto2B_WtoLNu_M-125",  # TODO: doesn't have xsec!
+        # "WplusH_Hto2B_WtoLNu_M-125",
         "WminusH_Hto2B_Wto2Q_M-125",
-        # "WminusH_Hto2B_WtoLNu_M-125",  # TODO: doesn't have xsec!
+        # "WminusH_Hto2B_WtoLNu_M-125",
         "ZH_Hto2B_Zto2Q_M-125",
         "ggZH_Hto2B_Zto2Q_M-125",
-        "ggZH_Hto2B_Zto2L_M-125",
-        "ggZH_Hto2B_Zto2Nu_M-125",
+        # "ggZH_Hto2B_Zto2L_M-125",
+        # "ggZH_Hto2B_Zto2Nu_M-125",
     ],
     "novhhtobb": ["GluGluHto2B_PT-200_M-125", "VBFHto2B_M-125_dipoleRecoilOn"],
     "tthtobb": ["ttHto2B_M-125"],
@@ -57,23 +56,22 @@ common_samples_sig = {}  # TODO: none yet
 samples_run3 = {
     "2022": {
         **common_samples_bg,
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
         "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
     },
     "2022EE": {
         **common_samples_bg,
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV"],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
         "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
     },
     "2023": {
         **common_samples_bg,
-        "hh4b": [
-            "GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?",
-            # "GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_TSG",
-        ],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
     },
     "2023BPix": {
         **common_samples_bg,
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_TSG"],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
+        # "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_TSG"],
     },
 }
 

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -257,17 +257,23 @@ def load_process_run3_samples(args, year, bdt_training_keys, control_plots, plot
         cutflow_dict[key]["HLT"] = np.sum(bdt_events["weight"].to_numpy())
 
         mask_presel = (
-            (bdt_events["H1Msd"] > 40)  # FIXME: replace by jet matched to trigger object
-            & (bdt_events["H1Pt"] > 300)
-            & (bdt_events["H2Pt"] > 300)
-            & (bdt_events["H1TXbb"] > 0.8)
+            (bdt_events["H1Msd"] >= 40)  # FIXME: replace by jet matched to trigger object
+            & (bdt_events["H1Pt"] >= 300)
+            & (bdt_events["H2Pt"] >= args.pt_second)
+            & (bdt_events["H1TXbb"] >= 0.8)
             & (bdt_events[args.mass] >= 60)
-            & (bdt_events[args.mass] <= 250)
+            & (bdt_events[args.mass] <= 220)
             & (bdt_events[args.mass.replace("H2", "H1")] >= 60)
-            & (bdt_events[args.mass.replace("H2", "H1")] <= 250)
+            & (bdt_events[args.mass.replace("H2", "H1")] <= 220)
         )
         bdt_events = bdt_events[mask_presel]
-        cutflow_dict[key]["H1Msd > 40 & Pt > 300"] = np.sum(bdt_events["weight"].to_numpy())
+        cutflow_dict[key][f"H1Msd > 40 & H2Pt > {args.pt_second}"] = np.sum(
+            bdt_events["weight"].to_numpy()
+        )
+
+        cutflow_dict[key]["BDT > min"] = np.sum(
+            bdt_events["weight"][bdt_events["bdt_score"] > args.bdt_wps[2]].to_numpy()
+        )
 
         ###### FINISH pre-selection
         mass_window = [110, 140]
@@ -996,6 +1002,10 @@ if __name__ == "__main__":
         nargs="+",
         default=["hh4b", "vbfhh4b-k2v0"],
         help="sig keys for which to make templates",
+    )
+
+    parser.add_argument(
+        "--pt-second", type=float, default=300, help="pt threshold for subleading jet"
     )
 
     run_utils.add_bool_arg(parser, "bdt-roc", default=False, help="make BDT ROC curve")

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -91,15 +91,6 @@ label_by_mass = {
     "H2PNetMass": r"$m^{2}_\mathrm{reg}$ (GeV)",
 }
 
-"""
-Test suggested by Marko
-- Fill data mass and BDT histogram before BDT (unblinded)
-- For one toy
-  - Sample mass histogram (TH1->GetRandom()) -> New mass histogram
-  - (LATER): Inject 3sigma HH4b
-  - Optimize for FOM using sideband
-"""
-
 
 def get_bdt_training_keys(bdt_model: str):
     inferences_dir = Path(f"../boosted/bdt_trainings_run3/{bdt_model}/inferences/2022EE")
@@ -348,7 +339,11 @@ def load_process_run3_samples(args, year, bdt_training_keys, control_plots, plot
         )
 
         mask_bin3 = (
-            ~(mask_bin1) & ~(mask_bin2) & (bdt_events["bdt_score"] > args.bdt_wps[2]) & ~(mask_vbf)
+            (bdt_events["H2TXbb"] > args.txbb_wps[1])
+            & (bdt_events["bdt_score"] > args.bdt_wps[2])
+            & ~(mask_bin1)
+            & ~(mask_bin2)
+            & ~(mask_vbf)
         )
         bdt_events.loc[mask_bin3, "Category"] = 3
         cutflow_dict[key]["Bin 3"] = np.sum(bdt_events["weight"][mask_bin3].to_numpy())
@@ -753,7 +748,7 @@ def postprocess_run3(args):
             processes,
             bg_keys=bg_keys_combined,
             scale_processes={
-                "hh4b": ["2022EE", "2023", "2023BPix"],
+                # "hh4b": ["2022EE", "2023", "2023BPix"], # FIXED
                 "vbfhh4b-k2v0": ["2022", "2022EE"],
             },
             years_run3=args.years,
@@ -764,6 +759,7 @@ def postprocess_run3(args):
         scaled_by = {}
 
     # combined cutflow
+    cutflow_combined = None
     if len(args.years) > 0:
         cutflow_combined = pd.DataFrame(index=list(events_combined.keys()))
 
@@ -871,9 +867,6 @@ def postprocess_run3(args):
         print("Making BDT ROC curve")
         bdt_roc(events_combined, plot_dir, args.legacy)
 
-    if not args.templates:
-        return
-
     templ_dir = Path("templates") / args.templates_tag
     year = "2022-2023"
     (templ_dir / "cutflows" / year).mkdir(parents=True, exist_ok=True)
@@ -885,7 +878,14 @@ def postprocess_run3(args):
         pretty_printer.pprint(vars(args))
 
     for cyear in args.years:
+        cutflows[cyear] = cutflows[cyear].round(2)
         cutflows[cyear].to_csv(templ_dir / "cutflows" / f"preselection_cutflow_{cyear}.csv")
+    if cutflow_combined is not None:
+        cutflow_combined = cutflow_combined.round(2)
+        cutflow_combined.to_csv(templ_dir / "cutflows" / "preselection_cutflow_combined.csv")
+
+    if not args.templates:
+        return
 
     if not args.vbf:
         selection_regions.pop("pass_vbf")

--- a/src/HH4b/postprocessing/postprocessing.py
+++ b/src/HH4b/postprocessing/postprocessing.py
@@ -32,19 +32,10 @@ class Region:
 
 
 mass_key = "bbFatJetPNetMassLegacy"
-# both jets pT > 300, both jets mass [50, 250]
 filters_legacy = [
     [
-        ("('bbFatJetPt', '0')", ">=", 300),
-        ("('bbFatJetPt', '1')", ">=", 300),
-        (f"('{mass_key}', '0')", "<=", 250),
-        (f"('{mass_key}', '1')", "<=", 250),
-        (f"('{mass_key}', '0')", ">=", 60),
-        (f"('{mass_key}', '1')", ">=", 60),
-    ],
-    [
-        ("('bbFatJetPt', '0')", ">=", 300),
-        ("('bbFatJetPt', '1')", ">=", 300),
+        ("('bbFatJetPt', '0')", ">=", 250),
+        ("('bbFatJetPt', '1')", ">=", 250),
         (f"('{mass_key}', '0')", "<=", 250),
         (f"('{mass_key}', '1')", "<=", 250),
         (f"('{mass_key}', '0')", ">=", 60),
@@ -67,20 +58,22 @@ filters_v12 = [
 HLTs = {
     "2022": [
         "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
-        #  'AK8PFJet425_SoftDropMass40',
+        "AK8PFJet425_SoftDropMass40",
     ],
     "2022EE": [
         "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
-        # 'AK8PFJet425_SoftDropMass40',
+        "AK8PFJet425_SoftDropMass40",
     ],
     "2023": [
         "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
         "AK8PFJet230_SoftDropMass40_PNetBB0p06",
-        # 'AK8PFJet425_SoftDropMass40',
+        # "AK8PFJet400_SoftDropMass40", #TODO: add to ntuples
+        "AK8PFJet425_SoftDropMass40",
     ],
     "2023BPix": [
         "AK8PFJet230_SoftDropMass40_PNetBB0p06",
-        #  'AK8PFJet425_SoftDropMass40',
+        # "AK8PFJet400_SoftDropMass40", #TODO: add to ntuples
+        "AK8PFJet425_SoftDropMass40",
     ],
 }
 
@@ -377,6 +370,7 @@ def get_templates(
 
         if template_dir != "":
             cf = cf.round(2)
+            print("cutflow ", rname, cf)
             cf.to_csv(f"{template_dir}/cutflows/{year}/{rname}_cutflow{jlabel}.csv")
 
         # # TODO: trigger uncertainties

--- a/src/HH4b/processors/bbbbSkimmer.py
+++ b/src/HH4b/processors/bbbbSkimmer.py
@@ -183,6 +183,7 @@ class bbbbSkimmer(SkimmerABC):
                     "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
                     "AK8PFJet230_SoftDropMass40_PNetBB0p06",
                     "AK8PFJet230_SoftDropMass40",
+                    "AK8PFJet400_SoftDropMass40",
                     "AK8PFJet425_SoftDropMass40",
                     "AK8PFJet420_MassSD30",
                 ],
@@ -190,6 +191,7 @@ class bbbbSkimmer(SkimmerABC):
                     "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
                     "AK8PFJet230_SoftDropMass40_PNetBB0p06",
                     "AK8PFJet230_SoftDropMass40",
+                    "AK8PFJet400_SoftDropMass40",
                     "AK8PFJet425_SoftDropMass40",
                     "AK8PFJet420_MassSD30",
                 ],
@@ -225,10 +227,12 @@ class bbbbSkimmer(SkimmerABC):
                     "AK8PFJet425_SoftDropMass40",
                     "AK8PFJet250_SoftDropMass40_PFAK8ParticleNetBB0p35",
                     "AK8PFJet230_SoftDropMass40",
+                    "AK8PFJet400_SoftDropMass40",
                     "AK8PFJet230_SoftDropMass40_PNetBB0p06",
                 ],
                 "2023BPix": [
                     "AK8PFJet230_SoftDropMass40",
+                    "AK8PFJet400_SoftDropMass40",
                     "AK8PFJet230_SoftDropMass40_PNetBB0p06",
                 ],
             },
@@ -854,7 +858,12 @@ class bbbbSkimmer(SkimmerABC):
         return accumulator
 
     def add_weights(
-        self, events, year, dataset, gen_weights, gen_selected, fatjets, num_fatjets_cut
+        self,
+        events,
+        year,
+        dataset,
+        gen_weights,
+        gen_selected,  # fatjets, num_fatjets_cut
     ) -> tuple[dict, dict]:
         """Adds weights and variations, saves totals for all norm preserving weights and variations"""
         weights = Weights(len(events), storeIndividual=True)
@@ -934,6 +943,7 @@ class bbbbSkimmer(SkimmerABC):
 
         # save the unnormalized weight, to confirm that it's been normalized in post-processing
         weights_dict["weight_noxsec"] = weights.weight()
+
         # weights_dict["trigger_sf"] = get_trig_weights(fatjets, year, num_fatjets_cut)
 
         return weights_dict, totals_dict


### PR DESCRIPTION
- [x] Replace all signal samples (kl=1) by official
- [x] Add argument to cut on pT>XX for sub-leading jet, lower pre-selection to 250 in load_samples
- [x] Add OR of other triggers in pre-selection
- [x] Add missing 2023 trigger in bbbbSkimmer, and fix pre-commit for non-existent trigger weights