### PR TITLE
added an option for user different from LPC-HH in run_utils.py

### DIFF
--- a/src/HH4b/run_utils.py
+++ b/src/HH4b/run_utils.py
@@ -38,11 +38,11 @@ def print_red(s):
     return print(f"{Fore.RED}{s}{Style.RESET_ALL}")
 
 
-def check_branch(git_branch: str, allow_diff_local_repo: bool = False):
+def check_branch(git_branch: str, git_user: str = "LPC-HH", allow_diff_local_repo: bool = False):
     """Check that specified git branch exists in the repo, and local repo is up-to-date"""
     assert not bool(
         os.system(
-            f'git ls-remote --exit-code --heads "https://github.com/LPC-HH/HH4b" "{git_branch}"'
+            f'git ls-remote --exit-code --heads "https://github.com/{git_user}/HH4b" "{git_branch}"'
         )
     ), f"Branch {git_branch} does not exist"
 

--- a/src/condor/submit.py
+++ b/src/condor/submit.py
@@ -33,7 +33,7 @@ def write_template(templ_file: str, out_file: str, templ_args: dict):
 
 def main(args):
     # check that branch exists
-    run_utils.check_branch(args.git_branch, args.allow_diff_local_repo)
+    run_utils.check_branch(args.git_branch, args.git_user, args.allow_diff_local_repo)
 
     if args.site == "lpc":
         try:


### PR DESCRIPTION
run_utils.py had the LPC-HH git user hard coded in the check_branch(...) method. Modified it as well as the submit.py script to allow users other than LPC-HH to run jobs with their own branches as reference.