### PR TITLE
GloParT v2 fixes

### DIFF
--- a/src/HH4b/corrections/data/ttbar_sfs/24Sep27_v5_glopartv2
+++ b/src/HH4b/corrections/data/ttbar_sfs/24Sep27_v5_glopartv2
@@ -1,0 +1,1 @@
+24May31_lr_0p02_md_8_AK4Away

--- a/src/HH4b/hh_vars.py
+++ b/src/HH4b/hh_vars.py
@@ -433,11 +433,11 @@ txbbsfs_decorr_pt_bins = OrderedDict(
 txbb_strings = {
     "pnet-legacy": "bbFatJetPNetTXbbLegacy",
     "pnet-v12": "bbFatJetPNetTXbb",
-    "globart-v2": "bbFatJetParTTXbb",
+    "glopart-v2": "bbFatJetParTTXbb",
 }
 
 mreg_strings = {
     "pnet-legacy": "bbFatJetPNetMassLegacy",
     "pnet-v12": "bbFatJetPNetMass",
-    "globart-v2": "bbFatJetParTmassVis",
+    "glopart-v2": "bbFatJetParTmassVis",
 }

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -415,8 +415,6 @@ def load_process_run3_samples(args, year, bdt_training_keys, control_plots, plot
                 bdt_events[f"H2PNetMass_{jshift}"] = events_dict[
                     f"{mreg_strings[args.txbb]}_{jshift}"
                 ][1]
-        bdt_events["H1TXbbNoLeg"] = events_dict["bbFatJetPNetTXbb"][0]
-        bdt_events["H2TXbbNoLeg"] = events_dict["bbFatJetPNetTXbb"][1]
 
         # add HLTs
         bdt_events["hlt"] = np.any(
@@ -1139,8 +1137,6 @@ def make_control_plots(events_dict, plot_dir, year, txbb_version):
         ShapeVar(var="H2Msd", label=r"$m_{SD}^{2}$ (GeV)", bins=[30, 0, 300]),
         ShapeVar(var="H1TXbb", label=r"Xbb$^{1}$ " + txbb_label, bins=[30, 0, 1]),
         ShapeVar(var="H2TXbb", label=r"Xbb$^{2}$ " + txbb_label, bins=[30, 0, 1]),
-        ShapeVar(var="H1TXbbNoLeg", label=r"Xbb$^{1}$ v12", bins=[30, 0, 1]),
-        ShapeVar(var="H2TXbbNoLeg", label=r"Xbb$^{2}$ v12", bins=[30, 0, 1]),
         ShapeVar(var="H1PNetMass", label=r"$m_{reg}^{1}$ (GeV) " + txbb_label, bins=[30, 0, 300]),
         ShapeVar(var="H2PNetMass", label=r"$m_{reg}^{2}$ (GeV) " + txbb_label, bins=[30, 0, 300]),
         ShapeVar(var="HHPt", label=r"HH $p_{T}$ (GeV)", bins=[30, 0, 4000]),


### PR DESCRIPTION
- [x] GloParT v2 typo fixes
- [x] use placeholder ttbar SFs (same as old BDT) for now
- [x] remove old pnet v12 control plots