### PR TITLE
parallelized load_process_run3_samples() across years

### DIFF
--- a/src/HH4b/log_utils.py
+++ b/src/HH4b/log_utils.py
@@ -5,7 +5,9 @@ log_config = {
     "version": 1,
     "disable_existing_loggers": False,  # this fixes the problem about many loggers
     "formatters": {
-        "default": {"format": "[%(asctime)s] %(levelname)-2s: %(name)-20s %(message)s"},
+        "default": {
+            "format": "[%(asctime)s] %(levelname)-2s: %(name)-20s [%(threadName)s] %(message)s"
+        },
     },
     "handlers": {
         "default": {


### PR DESCRIPTION
post processing should run somewhat faster now. 

TODO: 
- test
- add multithreading in utils.load_samples, could gain some speed there too

There seem to be multiple performance bottlenecks, the biggest one being that load_run3_samples currently loads all samples and then picks one sample to pass on, then repeats the loading. 
i.e.:
for sample in samples:
     load all samples
     return samples[sample]

This scales O(n^2) with samples instead of O(n), which would explain why the script slowed down so much as post processing got more extensive.

I looked at the possibility of applying multithreading there too, threading across samples, but the function is a bit too interleaved for that to be possible without major refactoring. 
The only other option would be to refactor load_samples_run3() to load single samples but that may break other applications