### PR TITLE
Add non-interactive EL7 wrapper for combine/DHI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ I also add the combine folder to my PATH in my .bashrc for convenience:
 export PATH="$PATH:/uscms_data/d1/rkansal/hh4b/HH4b/src/HH4b/combine"
 ```
 
+### Non-interactive entry to the EL7 environment
+
+For scripting, CI, or running combine commands without spawning an interactive
+container, `src/HH4b/combine/run_in_el7.sh` enters EL7, sets up CMSSW + DHI +
+PATH in one shot, and runs an arbitrary command:
+
+```bash
+src/HH4b/combine/run_in_el7.sh "cd cards/<TAG> && run_blinded_hh4b.sh -wbl --passbin 0"
+```
+
 ### Create Datacards
 
 After activating the CMSSW environment from above, need to install rhalphalib

--- a/src/HH4b/combine/run_in_el7.sh
+++ b/src/HH4b/combine/run_in_el7.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# One-shot wrapper that enters the EL7 singularity, sources CMSSW + DHI,
+# adds HH4b/combine to PATH, and runs the given command.
+#
+# Usage:
+#   run_in_el7.sh "<shell command(s)>"
+#
+# Example:
+#   run_in_el7.sh "cd /home/users/dprimosc/HH4b/cards/run3-bdt-26Mar31/ && run_blinded_hh4b.sh -l --passbin 0"
+
+set -e
+
+[ -f /tmp/dhi_constraints.txt ] || echo "osqp==0.6.7.post3" > /tmp/dhi_constraints.txt
+
+USER_CMD="$1"
+
+# IMPORTANT: keep the inner command as a single line. cmssw-el7 --command-to-run
+# passes its arg verbatim to /usr/bin/sh -c, where multi-line strings with
+# backslash continuations break the && chain. Single line, single-quoted outside,
+# inner $ references must be literal (so single-quote here — SC2016 is intentional).
+# shellcheck disable=SC2016
+PRELUDE='cd /home/users/dprimosc/HH4b/src/CMSSW_11_3_4/src && eval $(scram runtime -sh) && cd /home/users/dprimosc/HH4b/src/CMSSW_11_3_4/src/inference && export DHI_SCRAM_ARCH=slc7_amd64_gcc900 DHI_CMSSW_VERSION=CMSSW_11_3_4 DHI_COMBINE_VERSION=v9.1.0 PIP_CONSTRAINT=/tmp/dhi_constraints.txt && source setup.sh >/dev/null 2>&1 && export PATH=/home/users/dprimosc/HH4b/src/HH4b/combine:$PATH'
+
+/cvmfs/cms.cern.ch/common/cmssw-el7 --command-to-run "${PRELUDE} && ${USER_CMD}"


### PR DESCRIPTION
Adds src/HH4b/combine/run_in_el7.sh, a one-shot wrapper that enters the EL7 singularity via cmssw-el7 --command-to-run, sources CMSSW + DHI's setup.sh with EL7-compatible env vars (slc7_amd64_gcc900, CMSSW_11_3_4, combine v9.1.0), puts HH4b/combine on PATH, and then runs whatever command was passed.

The full inference pipeline (CreateDatacard.py, prepare_snapshot_inference.sh, run_blinded_hh4b.sh, run_inference_*.sh) is now runnable from a single non-interactive call, which removes the interactive-singularity blocker for scripting, CI, and remote orchestrators.

Gotchas captured in the wrapper:
- inner command must be a single logical line; multi-line + backslash continuations silently break the && chain inside cmssw-el7's sh -c
- prelude single-quoted so $(scram runtime -sh) and $PATH reach the inner shell unexpanded (SC2016 is intentional)
- /tmp/dhi_constraints.txt auto-recreated each invocation to keep pip's old TOML parser from choking on osqp's modern pyproject.toml