### PR TITLE
Migrate shape-plot infrastructure out of CombineTemplates notebook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ filterwarnings = [
   # upstream noise (nothing in HH4b triggers it) but would otherwise fail collection
   # of any test that imports the package under the "error" filter above.
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+  # hepdata_validator triggers jsonschema's deprecation warnings on import
+  "ignore:jsonschema.* is deprecated:DeprecationWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/src/HH4b/plotting.py
+++ b/src/HH4b/plotting.py
@@ -10,8 +10,6 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import mplhep as hep
 import numpy as np
-from hepdata_lib import Submission, Table, Uncertainty, Variable
-from hepdata_lib.hist_utils import read_hist
 from hist import Hist
 from hist.intervals import poisson_interval, ratio_uncertainty
 from matplotlib.ticker import MaxNLocator
@@ -271,6 +269,95 @@ def sigErrRatioPlot(
     rax.grid(axis="y")
 
     plt.savefig(f"{plot_dir}/{name}.pdf", bbox_inches="tight")
+    if show:
+        plt.show()
+    else:
+        plt.close()
+
+
+def jmsJmrComparisonPlot(
+    variations: dict,
+    jms_values: dict,
+    jmr_values: dict,
+    title: str = None,
+    xlabel: str = r"$m^\mathrm{reg}_{2}$ [GeV]",
+    ylabel: str = "Signal Yield",
+    original: Hist = None,
+    plot_dir: str = None,
+    name: str = None,
+    show: bool = False,
+    xlim: list = None,
+):
+    """Three-panel comparison of JMS/JMR mass-morphed templates.
+
+    Panel 1 overlays the nominal (and optionally a raw ``original`` JMS=1/JMR=1)
+    template; panels 2 and 3 show the JMS and JMR up/down variations.
+
+    Args:
+        variations: output of ``postprocessing.compute_jmsr_variations`` (keys
+            ``nominal``, ``jms_up``, ``jms_down``, ``jmr_up``, ``jmr_down``).
+        jms_values, jmr_values: ``{"nom","up","down"}`` scale/resolution values,
+            used only for the legend labels.
+        original: optional raw (JMS=1, JMR=1) template to overlay in panel 1.
+    """
+    nominal = variations["nominal"]
+    edges = nominal.axes[0].edges
+    ymax = np.max(nominal.values()) * 1.4
+
+    plt.figure(figsize=(21, 7))
+    ax1 = plt.subplot(131)
+    if original is not None:
+        hep.histplot(
+            original.values(),
+            edges,
+            yerr=np.sqrt(original.variances()),
+            histtype="step",
+            label="Original (JMS=1, JMR=1)",
+            ax=ax1,
+        )
+    hep.histplot(
+        nominal.values(),
+        edges,
+        yerr=np.sqrt(nominal.variances()),
+        histtype="step",
+        label=f"Nominal (JMS={jms_values['nom']}, JMR={jmr_values['nom']})",
+        ax=ax1,
+    )
+
+    ax2 = plt.subplot(132, sharey=ax1)
+    for key, scale in [("jms_down", jms_values["down"]), ("jms_up", jms_values["up"])]:
+        hep.histplot(
+            variations[key].values(),
+            edges,
+            yerr=np.sqrt(variations[key].variances()),
+            histtype="step",
+            label=f"{key.replace('_', ' ').upper()} (JMS={scale})",
+            ax=ax2,
+        )
+
+    ax3 = plt.subplot(133, sharey=ax1)
+    for key, smear in [("jmr_down", jmr_values["down"]), ("jmr_up", jmr_values["up"])]:
+        hep.histplot(
+            variations[key].values(),
+            edges,
+            yerr=np.sqrt(variations[key].variances()),
+            histtype="step",
+            label=f"{key.replace('_', ' ').upper()} (JMR={smear})",
+            ax=ax3,
+        )
+
+    for ax in [ax1, ax2, ax3]:
+        ax.legend(fontsize=18)
+        ax.set_ylim(0, ymax)
+        if xlim is not None:
+            ax.set_xlim(*xlim)
+        ax.set_xlabel(xlabel)
+    ax1.set_ylabel(ylabel)
+    if title is not None:
+        ax2.set_title(title)
+
+    if plot_dir is not None and name is not None:
+        plt.savefig(f"{plot_dir}/{name}.pdf", bbox_inches="tight")
     if show:
         plt.show()
     else:
@@ -962,6 +1049,15 @@ def ratioHistPlot(
         plt.close()
 
     if hepdata:
+        # hepdata_lib is only needed for HEPData export; keep it out of the import path
+        from hepdata_lib import (  # noqa: PLC0415
+            Submission,
+            Table,
+            Uncertainty,
+            Variable,
+        )
+        from hepdata_lib.hist_utils import read_hist  # noqa: PLC0415
+
         submission = Submission()
         tab = {}
         labels = {}

--- a/src/HH4b/postprocessing/CombineTemplates.ipynb
+++ b/src/HH4b/postprocessing/CombineTemplates.ipynb
@@ -6,7 +6,15 @@
    "source": [
     "# Combining templates and plotting systematic shifts\n",
     "\n",
-    "Author(s): Raghav Kansal, Javier Duarte"
+    "Author(s): Raghav Kansal, Javier Duarte\n",
+    "\n",
+    "Thin driver over the shape-plot infrastructure that now lives in the package:\n",
+    "\n",
+    "- `HH4b.utils.combine_hists` / `rename_sample_axis` &mdash; histogram surgery\n",
+    "- `HH4b.postprocessing.combine_templates` &mdash; sum per-year templates + weight/JEC/JMSR dispatch\n",
+    "- `HH4b.postprocessing.get_shape_systematics` / `compute_jmsr_variations`\n",
+    "- `HH4b.postprocessing.PlotShapes.make_shape_plots` &mdash; the loop driver (also a CLI script)\n",
+    "- `HH4b.plotting.sigErrRatioPlot` / `jmsJmrComparisonPlot`"
    ]
   },
   {
@@ -14,53 +22,34 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from __future__ import annotations\n",
-    "\n",
-    "import pickle\n",
-    "import warnings\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import hist\n",
-    "import numpy as np\n",
-    "from hist import Hist\n",
-    "\n",
-    "from HH4b import plotting, utils\n",
-    "from HH4b.hh_vars import jecs, jmsr\n",
-    "from HH4b.postprocessing import Region, get_weight_shifts\n",
-    "\n",
-    "weight_shifts = get_weight_shifts(\"glopart-v2\", \"24Nov7_v5_glopartv2_rawmass\")"
-   ]
+   "source": "from __future__ import annotations\n\nimport pickle\nfrom pathlib import Path\n\nfrom HH4b import plotting\nfrom HH4b.hh_vars import jmsr_values\nfrom HH4b.postprocessing import (\n    Region,\n    combine_templates,\n    compute_jmsr_variations,  # noqa: F401  (used in the analytic cross-check below)\n    get_weight_shifts,\n)\nfrom HH4b.postprocessing.PlotShapes import default_shape_plot_dir, make_shape_plots\n\ntxbb_version = \"glopart-v3\"\nbdt_version = \"25Feb5_v13_glopartv2_rawmass\"\nweight_shifts = get_weight_shifts(txbb_version, bdt_version)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
+   "source": "%load_ext autoreload\n%autoreload 2"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "templates_path = Path(\n",
-    "    \"/home/users/woodson/HH4b/src/HH4b/postprocessing/templates/25Mar17GloParTv2BDTv13SplitDiboson\"\n",
-    ")\n",
-    "# templates_path_original = Path(\n",
-    "#    \"/home/users/woodson/HH4b/src/HH4b/postprocessing/templates/24Nov11GloParTv2ZichunPRNoTTbarSF\"\n",
-    "# )"
-   ]
+   "source": "import matplotlib.pyplot as plt\nimport mplhep as hep\n\nplt.style.use(hep.style.CMS)\nhep.style.use(\"CMS\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "templates_path = Path(\n    \"/home/users/dprimosc/HH4b/src/HH4b/postprocessing/templates/26Mar10_split2024MC\"\n)\nyears = [\"2022\", \"2022EE\", \"2023\", \"2023BPix\", \"2024\", \"2025\"]\n\ntemplates = {}\nfor year in years:\n    with (templates_path / f\"{year}_templates.pkl\").open(\"rb\") as f:\n        templates[year] = pickle.load(f)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combining templates"
+    "## Plot systematic shape variations"
    ]
   },
   {
@@ -68,24 +57,22 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "templates = {}\n",
-    "templates_original = {}\n",
-    "\n",
-    "years = [\"2022\", \"2022EE\", \"2023\", \"2023BPix\"]\n",
-    "for year in years:\n",
-    "    with (templates_path / f\"{year}_templates.pkl\").open(\"rb\") as f:\n",
-    "        templates[year] = pickle.load(f)\n",
-    "\n",
-    "    # with (templates_path_original / f\"{year}_templates.pkl\").open(\"rb\") as f:\n",
-    "    #    templates_original[year] = pickle.load(f)"
-   ]
+   "source": "# output dir derived from the template-set name:\n# <repo>/plots/PostProcess/<tag>/Templates/<years>/wshifts\nplot_dir = default_shape_plot_dir(templates_path, years)\nplot_dir.mkdir(parents=True, exist_ok=True)\n\nselection_regions = {\n    \"pass_bin1\": Region(cuts={\"Category\": [1, 2]}, label=\"Bin1\"),\n    \"pass_bin2\": Region(cuts={\"Category\": [2, 3]}, label=\"Bin2\"),\n    \"pass_bin3\": Region(cuts={\"Category\": [3, 4]}, label=\"Bin3\"),\n    \"fail\": Region(cuts={\"Category\": [4, 5]}, label=\"Fail\"),\n}"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sig_key = \"hh4b\"\nxlabel = r\"$m^\\mathrm{reg}_{2}$ (GeV)\"\n# `shifts=None` plots every systematic applicable to `sig_key`\n# (weight shifts from `weight_shifts` + JES/JER/JMS/JMR). Pass an explicit list\n# to restrict, e.g. shifts=[\"JMR\"].\nmake_shape_plots(\n    templates,\n    years,\n    {\"pass_bin1\": selection_regions[\"pass_bin1\"]},\n    sig_key,\n    weight_shifts,\n    plot_dir=plot_dir,\n    xlabel=xlabel,\n    shifts=[\"JMR\"],\n    ylim=[0, 2.5],\n    show=True,\n)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Testing JES plots"
+    "### Single shift, low-level\n",
+    "\n",
+    "Equivalent to one iteration of `make_shape_plots` &mdash; useful for interactive tweaking."
    ]
   },
   {
@@ -93,36 +80,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": "region = selection_regions[\"pass_bin1\"]\nwshift = \"JMR\"\n\nh = combine_templates(templates, years, \"pass_bin1\", wshift)\nplotting.sigErrRatioPlot(\n    h,\n    sig_key,\n    wshift,\n    xlabel,\n    f\"{region.label} Region {wshift} Variations\",\n    plot_dir,\n    f\"pass_bin1_sig_{wshift}\",\n    show=True,\n    ylim=[0, 2.5],\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "main_plot_dir = Path(\"plots/PostProcessing/25Mar17GloParTv2BDTv13SplitDiboson/Templates\")\n",
+    "## JMS/JMR morphing cross-check\n",
     "\n",
-    "\n",
-    "selection_regions = {\n",
-    "    \"pass_bin1\": Region(\n",
-    "        cuts={\n",
-    "            \"Category\": [1, 2],\n",
-    "        },\n",
-    "        label=\"Bin1\",\n",
-    "    ),\n",
-    "    \"pass_bin2\": Region(\n",
-    "        cuts={\n",
-    "            \"Category\": [2, 3],\n",
-    "        },\n",
-    "        label=\"Bin2\",\n",
-    "    ),\n",
-    "    \"pass_bin3\": Region(\n",
-    "        cuts={\n",
-    "            \"Category\": [3, 4],\n",
-    "        },\n",
-    "        label=\"Bin3\",\n",
-    "    ),\n",
-    "    \"fail\": Region(\n",
-    "        cuts={\n",
-    "            \"Category\": [4, 5],\n",
-    "        },\n",
-    "        label=\"Fail\",\n",
-    "    ),\n",
-    "}"
+    "The stored JMS/JMR-shifted templates pulled straight from the pickles (via\n",
+    "`combine_templates`), shown as a three-panel comparison."
    ]
   },
   {
@@ -130,25 +97,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": "year = \"2022\"\nmass_obs = \"bbFatJetParTmassVis\"\n\nh_jms = combine_templates(templates, years, \"pass_bin1\", \"JMS\")\nh_jmr = combine_templates(templates, years, \"pass_bin1\", \"JMR\")\nvariations = {\n    \"nominal\": h_jms[sig_key, :],\n    \"jms_up\": h_jms[f\"{sig_key}_JMS_up\", :],\n    \"jms_down\": h_jms[f\"{sig_key}_JMS_down\", :],\n    \"jmr_up\": h_jmr[f\"{sig_key}_JMR_up\", :],\n    \"jmr_down\": h_jmr[f\"{sig_key}_JMR_down\", :],\n}\n\njms = jmsr_values[mass_obs][\"JMS\"][year]\njmr = jmsr_values[mass_obs][\"JMR\"][year]\nplotting.jmsJmrComparisonPlot(\n    variations,\n    jms,\n    jmr,\n    title=\"ggF HH4b (stored shifts)\",\n    xlim=[60, 220],\n    plot_dir=plot_dir,\n    name=\"hh4b_jms_jmr_stored\",\n    show=True,\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "def combine_hists(*hists):\n",
-    "    csamples = []\n",
-    "    for h in hists:\n",
-    "        csamples += list(h.axes[0])\n",
+    "#### Analytic cross-check (needs raw-mass templates)\n",
     "\n",
-    "    reth = Hist(\n",
-    "        hist.axis.StrCategory(csamples, name=\"Sample\"),\n",
-    "        *hists[0].axes[1:],\n",
-    "        storage=\"weight\",\n",
-    "    )\n",
-    "\n",
-    "    for h in hists:\n",
-    "        for sample in h.axes[0]:\n",
-    "            reth.view(flow=True)[utils.get_key_index(reth, sample), ...] = h[sample, ...].view(\n",
-    "                flow=True\n",
-    "            )\n",
-    "\n",
-    "    return reth"
+    "`compute_jmsr_variations` applies `smorph` to a **raw** (JMS=1, JMR=1) template\n",
+    "and reproduces the nominal/JMS/JMR shapes analytically. Load a raw-mass templates\n",
+    "dir as `templates_raw`, then run the cell below."
    ]
   },
   {
@@ -156,228 +115,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib.ticker as mticker\n",
-    "import mplhep as hep\n",
-    "\n",
-    "plt.style.use(hep.style.CMS)\n",
-    "hep.style.use(\"CMS\")\n",
-    "formatter = mticker.ScalarFormatter(useMathText=True)\n",
-    "formatter.set_powerlimits((-3, 3))\n",
-    "\n",
-    "# this is needed for some reason to update the font size for the first plot\n",
-    "fig, ax = plt.subplots(1, 1, figsize=(12, 12))\n",
-    "plt.rcParams.update({\"font.size\": 24})\n",
-    "plt.close()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "warnings.filterwarnings(\"ignore\")\n",
-    "\n",
-    "sig_key = \"hh4b\"\n",
-    "# sig_key = \"vbfhh4b-k2v0\"\n",
-    "# sig_key = \"ttbar\"\n",
-    "# sig_key = \"vbfhh4b-kvm0p962-k2v0p959-klm1p43\"\n",
-    "# sig_key = \"diboson\"\n",
-    "\n",
-    "for rname, region in selection_regions.items():\n",
-    "    if rname != \"pass_bin1\":\n",
-    "        continue\n",
-    "    plot_dir = main_plot_dir / \"2022-2023\" / \"wshifts\"\n",
-    "    plot_dir.mkdir(exist_ok=True, parents=True)\n",
-    "    # for wshift in list((jecs).keys()):\n",
-    "    for wshift in [\n",
-    "        # \"scale\",\n",
-    "        # \"pdf\",\n",
-    "        # \"ttbarSF_Xbb_bin_0_0.8\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.8_0.94\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.94_0.99\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.99_1\",\n",
-    "        # \"ttbarSF_Xbb_bin_0_0.31\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.31_0.7\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.7_0.8\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.8_0.87\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.87_0.92\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.92_0.96\",\n",
-    "        # \"ttbarSF_Xbb_bin_0.96_1\",\n",
-    "        # \"ttbarSF_pTjj\",\n",
-    "        # \"ttbarSF_tau32\",\n",
-    "        # \"ttbarSF_BDT_bin_0.03_0.3\",\n",
-    "        # \"ttbarSF_BDT_bin_0.3_0.5\",\n",
-    "        # \"ttbarSF_BDT_bin_0.5_0.7\",\n",
-    "        # \"ttbarSF_BDT_bin_0.7_0.93\",\n",
-    "        # \"ttbarSF_BDT_bin_0.93_1.0\",\n",
-    "        # \"trigger\"\n",
-    "        # \"TXbbSF_correlated\",\n",
-    "        # \"TXbbSF_uncorrelated_WP1_pT_bin_250_300\",\n",
-    "        # \"TXbbSF_uncorrelated_WP1_pT_bin_300_400\",\n",
-    "        # \"TXbbSF_uncorrelated_WP1_pT_bin_400_500\",\n",
-    "        # \"TXbbSF_uncorrelated_WP1_pT_bin_500_100000\",\n",
-    "        \"JMR\",\n",
-    "        # \"JMS\",\n",
-    "        # \"JER\"\n",
-    "    ]:\n",
-    "        if wshift in jecs or wshift in jmsr:\n",
-    "            # adding jshift-ed histograms into the same histogram\n",
-    "            cjshift_templates = [sum([templates[year][rname] for year in years])]\n",
-    "            for shift in [\"up\", \"down\"]:\n",
-    "                # new histogram with sample names renamed to \"{sample}_{jsf}_{shift}\"\n",
-    "                jt = sum([templates[year][f\"{rname}_{wshift}_{shift}\"] for year in years])\n",
-    "                slabels = [f\"{s}_{wshift}_{shift}\" for s in jt.axes[0]]\n",
-    "                rjt = Hist(\n",
-    "                    hist.axis.StrCategory(slabels, name=\"Sample\"),\n",
-    "                    *jt.axes[1:],\n",
-    "                    storage=\"weight\",\n",
-    "                )\n",
-    "                rjt.view()[...] = jt.view()\n",
-    "                cjshift_templates.append(rjt)\n",
-    "\n",
-    "                cjt = combine_hists(*cjshift_templates)\n",
-    "                shift_label = wshift\n",
-    "        else:\n",
-    "            shift_label = weight_shifts[wshift].label\n",
-    "            cjt = sum([templates[year][rname] for year in years])\n",
-    "\n",
-    "        plotting.sigErrRatioPlot(\n",
-    "            cjt,\n",
-    "            sig_key,\n",
-    "            wshift,\n",
-    "            \"$m_{reg}^{2}$ (GeV)\",\n",
-    "            f\"{region.label} Region {shift_label} Variations\",\n",
-    "            plot_dir,\n",
-    "            f\"{rname}_sig_{wshift}\",\n",
-    "            show=True,\n",
-    "            ylim=[0, 2.5],\n",
-    "            # h_uncorr=sum([templates_original[year][rname] for year in years]),\n",
-    "        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from HH4b.hh_vars import jmsr_values\n",
-    "from HH4b.postprocessing.datacardHelpers import smorph\n",
-    "\n",
-    "jms_values = jmsr_values[\"JMS\"]\n",
-    "jmr_values = jmsr_values[\"JMR\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "templ = templates_original[\"pass_bin1\"][\"hh4b\", :]\n",
-    "templ_nominal = smorph(templ, \"hh4b\", jms_values[year][\"nom\"], jmr_values[year][\"nom\"])\n",
-    "templ_jms_dn = smorph(templ, \"hh4b\", jms_values[year][\"down\"], jmr_values[year][\"nom\"])\n",
-    "templ_jms_up = smorph(templ, \"hh4b\", jms_values[year][\"up\"], jmr_values[year][\"nom\"])\n",
-    "templ_jmr_dn = smorph(templ, \"hh4b\", jms_values[year][\"nom\"], jmr_values[year][\"down\"])\n",
-    "templ_jmr_up = smorph(templ, \"hh4b\", jms_values[year][\"nom\"], jmr_values[year][\"up\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "templ = templates_original[\"pass_bin1\"][\"hh4b\", :]\n",
-    "templ_nominal = templates[\"pass_bin1\"][\"hh4b\", :]\n",
-    "templ_jms_dn = templates[\"pass_bin1_JMS_down\"][\"hh4b\", :]\n",
-    "templ_jms_up = templates[\"pass_bin1_JMS_up\"][\"hh4b\", :]\n",
-    "templ_jmr_dn = templates[\"pass_bin1_JMR_down\"][\"hh4b\", :]\n",
-    "templ_jmr_up = templates[\"pass_bin1_JMR_up\"][\"hh4b\", :]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import mplhep as hep\n",
-    "import numpy as np\n",
-    "\n",
-    "edges = templ.axes[0].edges\n",
-    "var_name = templ.axes[0].name\n",
-    "ymax = np.max(templ.values()) * 1.4\n",
-    "\n",
-    "plt.figure(figsize=(21, 7))\n",
-    "ax1 = plt.subplot(131)\n",
-    "hep.histplot(\n",
-    "    templ.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=\"Original (JMS=1, JMR=1)\",\n",
-    ")\n",
-    "hep.histplot(\n",
-    "    templ_nominal.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ_nominal.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=f\"Nominal (JMS={jms_values[year]['nom']}, JMR={jmr_values[year]['nom']})\",\n",
-    ")\n",
-    "ax2 = plt.subplot(132, sharey=ax1)\n",
-    "hep.histplot(\n",
-    "    templ_jms_dn.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ_jms_dn.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=f\"JMS Down (JMS={jms_values[year]['down']})\",\n",
-    ")\n",
-    "hep.histplot(\n",
-    "    templ_jms_up.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ_jms_up.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=f\"JMS Up (JMS={jms_values[year]['up']})\",\n",
-    ")\n",
-    "ax3 = plt.subplot(133, sharey=ax1)\n",
-    "hep.histplot(\n",
-    "    templ_jmr_dn.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ_jmr_dn.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=f\"JMR Down (JMR={jmr_values[year]['down']})\",\n",
-    ")\n",
-    "hep.histplot(\n",
-    "    templ_jmr_up.values(),\n",
-    "    edges,\n",
-    "    yerr=np.sqrt(templ_jmr_up.variances()),\n",
-    "    histtype=\"step\",\n",
-    "    label=f\"JMR Up (JMR={jmr_values[year]['up']})\",\n",
-    ")\n",
-    "\n",
-    "for ax in [ax1, ax2, ax3]:\n",
-    "    ax.legend(fontsize=18)\n",
-    "    ax.set_ylim(0, ymax)\n",
-    "    ax.set_xlim(60, 220)\n",
-    "    ax.set_xlabel(\"$m^{j2}_{reg}$ [GeV]\")\n",
-    "\n",
-    "ax1.set_ylabel(\"Signal Yield\")\n",
-    "ax2.set_title(f\"ggF HH4b ({year})\")\n",
-    "plt.savefig(main_plot_dir / f\"hh4b_jms_jmr_{year}.pdf\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": "# templates_raw = ...  # load a raw-mass templates dir like `templates` above\n#\n# templ_raw = combine_templates(templates_raw, years, \"pass_bin1\")[sig_key, :]\n# variations_analytic = compute_jmsr_variations(templ_raw, sig_key, year, mass_obs)\n# plotting.jmsJmrComparisonPlot(\n#     variations_analytic,\n#     jms,\n#     jmr,\n#     title=f\"ggF HH4b ({year}) -- analytic morph\",\n#     original=templ_raw,\n#     xlim=[60, 220],\n#     plot_dir=plot_dir,\n#     name=f\"hh4b_jms_jmr_{year}_analytic\",\n#     show=True,\n# )"
   }
  ],
  "metadata": {

--- a/src/HH4b/postprocessing/PlotShapes.py
+++ b/src/HH4b/postprocessing/PlotShapes.py
@@ -1,0 +1,201 @@
+"""Plot per-systematic template shape variations (signal up/down vs nominal).
+
+Migrates the driver logic from ``CombineTemplates.ipynb`` into a reusable
+function (:func:`make_shape_plots`) plus a script entry point. For each region and
+systematic shift it combines the per-year templates with
+``postprocessing.combine_templates`` and draws the variation with
+``plotting.sigErrRatioPlot``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+import warnings
+from pathlib import Path
+
+from HH4b import plotting, run_utils
+from HH4b.hh_vars import jecs, jmsr
+from HH4b.postprocessing import (
+    Region,
+    combine_templates,
+    get_shape_systematics,
+    get_weight_shifts,
+    shift_available,
+)
+
+# repo root of this checkout (…/src/HH4b/postprocessing/PlotShapes.py -> root)
+HH4B_DIR = Path(__file__).resolve().parents[3]
+
+
+def _year_label(years: list[str]) -> str:
+    """Compact label for a set of years, e.g. ``2022-2025`` (single year -> itself)."""
+    prefixes = sorted({str(year)[:4] for year in years})
+    return prefixes[0] if len(prefixes) == 1 else f"{prefixes[0]}-{prefixes[-1]}"
+
+
+def _templates_repo_root(templates_dir: str | Path) -> Path:
+    """Repo root the templates belong to (the ancestor containing ``src/HH4b``), so
+    plots land alongside the templates regardless of where the code runs from."""
+    for ancestor in Path(templates_dir).resolve().parents:
+        if (ancestor / "src" / "HH4b").is_dir():
+            return ancestor
+    return HH4B_DIR
+
+
+def default_shape_plot_dir(templates_dir: str | Path, years: list[str]) -> Path:
+    """Standard output dir for shape-systematic plots, derived from the template-set
+    name: ``<repo>/plots/PostProcess/<tag>/Templates/<year_label>/wshifts``."""
+    tag = Path(templates_dir).name
+    return (
+        _templates_repo_root(templates_dir)
+        / "plots"
+        / "PostProcess"
+        / tag
+        / "Templates"
+        / _year_label(years)
+        / "wshifts"
+    )
+
+
+def make_shape_plots(
+    templates: dict[str, dict],
+    years: list[str],
+    selection_regions: dict[str, Region],
+    sig_key: str,
+    weight_shifts: dict,
+    plot_dir: str | Path,
+    xlabel: str,
+    shifts: list[str] | None = None,
+    ylim: list | None = None,
+    show: bool = False,
+):
+    """Draw nominal vs up/down shape variations for each region and shift.
+
+    Args:
+        templates: ``{year: {region_key: Hist}}`` as loaded from the per-year pickles.
+        years: years to sum over.
+        selection_regions: ``{region_name: Region}`` to plot.
+        sig_key: sample whose variations are drawn (e.g. ``"hh4b"``).
+        weight_shifts: output of ``get_weight_shifts`` (used for labels and, when
+            ``shifts`` is ``None``, to enumerate applicable systematics).
+        plot_dir: output directory (created if missing).
+        xlabel: x-axis label for the mass variable.
+        shifts: explicit list of shift names; if ``None`` they are enumerated with
+            ``get_shape_systematics`` for ``sig_key``.
+        ylim: y-limits for the ratio panel.
+        show: whether to display each figure.
+    """
+    plot_dir = Path(plot_dir)
+    plot_dir.mkdir(parents=True, exist_ok=True)
+
+    if shifts is None:
+        shifts = get_shape_systematics(weight_shifts, sig_key)
+
+    for rname, region in selection_regions.items():
+        for shift in shifts:
+            if not shift_available(templates, years, rname, shift, sig_key):
+                warnings.warn(
+                    f"skipping '{shift}' for region '{rname}': shifted templates not found",
+                    stacklevel=2,
+                )
+                continue
+            h = combine_templates(templates, years, rname, shift)
+            is_jshift = shift in jecs or shift in jmsr
+            label = shift if is_jshift else weight_shifts[shift].label
+            plotting.sigErrRatioPlot(
+                h,
+                sig_key,
+                shift,
+                xlabel,
+                f"{region.label} Region {label} Variations",
+                plot_dir,
+                f"{rname}_sig_{shift}",
+                show=show,
+                ylim=ylim,
+            )
+
+
+def _default_selection_regions() -> dict[str, Region]:
+    return {
+        "pass_bin1": Region(cuts={"Category": [1, 2]}, label="Bin1"),
+        "pass_bin2": Region(cuts={"Category": [2, 3]}, label="Bin2"),
+        "pass_bin3": Region(cuts={"Category": [3, 4]}, label="Bin3"),
+        "fail": Region(cuts={"Category": [4, 5]}, label="Fail"),
+    }
+
+
+def plot_shapes(args):
+    templates_path = Path(args.templates_dir)
+    templates = {}
+    for year in args.years:
+        with (templates_path / f"{year}_templates.pkl").open("rb") as f:
+            templates[year] = pickle.load(f)
+
+    weight_shifts = get_weight_shifts(args.txbb_version, args.bdt_version)
+
+    selection_regions = _default_selection_regions()
+    if args.regions != "all":
+        selection_regions = {args.regions: selection_regions[args.regions]}
+
+    plots_dir = (
+        Path(args.plots_dir)
+        if args.plots_dir
+        else default_shape_plot_dir(args.templates_dir, args.years)
+    )
+    print(f"Saving shape plots to {plots_dir}")
+
+    make_shape_plots(
+        templates,
+        args.years,
+        selection_regions,
+        args.sig_key,
+        weight_shifts,
+        plot_dir=plots_dir,
+        xlabel=args.xlabel,
+        shifts=args.shifts,
+        ylim=args.ratio_ylims,
+        show=args.show,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--templates-dir", required=True, type=str, help="per-year templates dir")
+    parser.add_argument(
+        "--plots-dir",
+        default=None,
+        type=str,
+        help="output plots dir (default: <repo>/plots/PostProcess/<tag>/Templates/<years>/wshifts)",
+    )
+    parser.add_argument(
+        "--years",
+        nargs="+",
+        default=["2022", "2022EE", "2023", "2023BPix"],
+        help="years to combine",
+    )
+    parser.add_argument(
+        "--regions",
+        default="all",
+        choices=["pass_bin1", "pass_bin2", "pass_bin3", "fail", "all"],
+        help="region(s) to plot",
+    )
+    parser.add_argument("--sig-key", default="hh4b", type=str, help="signal sample to plot")
+    parser.add_argument("--txbb-version", default="glopart-v2", type=str)
+    parser.add_argument("--bdt-version", default="25Feb5_v13_glopartv2_rawmass", type=str)
+    parser.add_argument(
+        "--shifts",
+        nargs="+",
+        default=None,
+        help="explicit shift names; default enumerates all applicable to --sig-key",
+    )
+    parser.add_argument(
+        "--xlabel", default=r"$m^\mathrm{reg}_{2}$ (GeV)", type=str, help="mass axis label"
+    )
+    parser.add_argument(
+        "--ratio-ylims", nargs=2, default=[0, 2.5], type=float, help="ratio panel y-limits"
+    )
+    run_utils.add_bool_arg(parser, "show", default=False, help="show figures")
+
+    args = parser.parse_args()
+    plot_shapes(args)

--- a/src/HH4b/postprocessing/postprocessing.py
+++ b/src/HH4b/postprocessing/postprocessing.py
@@ -18,6 +18,7 @@ from HH4b.hh_vars import (
     bg_keys,
     data_key,
     jec_shifts,
+    jecs,
     jmsr,
     jmsr_keys,
     jmsr_res,
@@ -271,6 +272,130 @@ def get_weight_shifts(txbb_version: str, bdt_version: str):
                 years=years + ["2022-2023"],
             )
     return weight_shifts
+
+
+def _sum_over_years(templates: dict[str, dict[str, Hist]], years: list[str], key: str) -> Hist:
+    """Sum ``templates[year][key]`` over ``years``, tolerating per-year Sample-axis
+    differences. The Sample axes are unioned (preserving first-seen order); each year
+    is realigned to that union with missing samples zero-filled (so a sample present
+    only in some years, e.g. ``qcd`` absent from 2024/2025, sums over the years that
+    have it). Mismatched non-Sample axes (e.g. binning) still raise via the sum."""
+    hists = [templates[year][key] for year in years]
+
+    union = list(hists[0].axes[0])
+    seen = set(union)
+    for h in hists[1:]:
+        for sample in h.axes[0]:
+            if sample not in seen:
+                seen.add(sample)
+                union.append(sample)
+
+    aligned = [
+        h if list(h.axes[0]) == union else utils.align_sample_axis(h, union, fill_missing=True)
+        for h in hists
+    ]
+    return sum(aligned)
+
+
+def combine_templates(
+    templates: dict[str, dict[str, Hist]],
+    years: list[str],
+    region: str,
+    shift: str | None = None,
+) -> Hist:
+    """Sum a region's per-year templates into a single plot-ready histogram.
+
+    Weight-based systematics are stored as ``{sample}_{shift}_{up,down}`` Sample
+    categories inside the nominal histogram, so for those (and for the nominal,
+    ``shift=None``) this just sums across ``years``.
+
+    JEC/JMSR systematics (``shift`` in ``jecs`` or ``jmsr``) live in separate
+    per-year histograms keyed ``{region}_{shift}_{up,down}``; those are summed
+    across years, their samples renamed to ``{sample}_{shift}_{up,down}``, and
+    concatenated onto the nominal histogram so that ``plotting.sigErrRatioPlot``
+    can find the up/down categories.
+    """
+    nominal = _sum_over_years(templates, years, region)
+
+    if shift is None or (shift not in jecs and shift not in jmsr):
+        return nominal
+
+    combined = [nominal]
+    for direction in ["up", "down"]:
+        shifted = _sum_over_years(templates, years, f"{region}_{shift}_{direction}")
+        combined.append(utils.rename_sample_axis(shifted, f"_{shift}_{direction}"))
+
+    return utils.combine_hists(*combined)
+
+
+def shift_available(
+    templates: dict[str, dict[str, Hist]],
+    years: list[str],
+    region: str,
+    shift: str,
+    sample: str,
+) -> bool:
+    """Whether ``combine_templates`` can build ``shift`` for ``region``/``sample``.
+
+    JEC/JMSR shifts need ``{region}_{shift}_{up,down}`` histograms present for every
+    year; weight shifts need the ``{sample}_{shift}_{up,down}`` Sample categories in
+    the nominal histogram. Lets a driver skip systematics absent from a template set
+    (e.g. a JES variation that was never produced).
+    """
+    if shift in jecs or shift in jmsr:
+        return all(
+            f"{region}_{shift}_up" in templates[year]
+            and f"{region}_{shift}_down" in templates[year]
+            for year in years
+        )
+    nominal = templates[years[0]][region]
+    return f"{sample}_{shift}_up" in nominal.axes[0]
+
+
+def get_shape_systematics(
+    weight_shifts: dict,
+    sample: str,
+    include_jec: bool = True,
+    include_jmsr: bool = True,
+) -> list[str]:
+    """List the systematic shift names applicable to ``sample`` for shape plots.
+
+    Returns the weight shifts whose ``samples`` include ``sample``, followed by
+    the JEC and/or JMSR shift names.
+    """
+    shifts = [wshift for wshift, wsyst in weight_shifts.items() if sample in wsyst.samples]
+    if include_jec:
+        shifts += list(jecs)
+    if include_jmsr:
+        shifts += list(jmsr)
+    return shifts
+
+
+def compute_jmsr_variations(
+    templ: Hist,
+    sample_name: str,
+    year: str,
+    mass_obs: str = "bbFatJetParTmassVis",
+) -> dict[str, Hist]:
+    """Morph a 1D mass template with the JMS/JMR scale & resolution values.
+
+    Applies ``smorph`` to produce the nominally-smeared template plus the JMS and
+    JMR up/down variations for ``year``, returning a dict keyed ``nominal``,
+    ``jms_up``, ``jms_down``, ``jmr_up``, ``jmr_down``. This is the reusable form
+    of the JMS/JMR morphing cross-check from ``CombineTemplates.ipynb``.
+    """
+    # smorph pulls in rhalphalib (MorphHistW2), which is not a core/CI dependency
+    from HH4b.postprocessing.datacardHelpers import smorph  # noqa: PLC0415
+
+    jms = jmsr_values[mass_obs]["JMS"][year]
+    jmr = jmsr_values[mass_obs]["JMR"][year]
+    return {
+        "nominal": smorph(templ, sample_name, jms["nom"], jmr["nom"]),
+        "jms_up": smorph(templ, sample_name, jms["up"], jmr["nom"]),
+        "jms_down": smorph(templ, sample_name, jms["down"], jmr["nom"]),
+        "jmr_up": smorph(templ, sample_name, jms["nom"], jmr["up"]),
+        "jmr_down": smorph(templ, sample_name, jms["nom"], jmr["down"]),
+    }
 
 
 def load_run3_samples(

--- a/src/HH4b/utils.py
+++ b/src/HH4b/utils.py
@@ -443,6 +443,80 @@ def get_key_index(h: Hist, axis_name: str):
     return np.where(np.array(list(h.axes[0])) == axis_name)[0][0]
 
 
+def rename_sample_axis(h: Hist, suffix: str) -> Hist:
+    """Return a copy of ``h`` with ``suffix`` appended to every label of its first
+    (``Sample``) axis. All other axes, values, variances and flow bins are preserved.
+    """
+    new_labels = [f"{sample}{suffix}" for sample in h.axes[0]]
+    reth = Hist(
+        hist.axis.StrCategory(new_labels, name=h.axes[0].name),
+        *h.axes[1:],
+        storage=h.storage_type(),
+    )
+    reth.view(flow=True)[...] = h.view(flow=True)
+    return reth
+
+
+def combine_hists(*hists: Hist) -> Hist:
+    """Concatenate histograms along their first (``Sample``) StrCategory axis.
+
+    All inputs must share identical non-``Sample`` axes, and sample labels must be
+    unique across inputs (duplicates would make name-based indexing ambiguous).
+    Values, variances and flow bins are carried through unchanged.
+    """
+    if not hists:
+        raise ValueError("combine_hists requires at least one histogram")
+
+    ref_axes = hists[0].axes[1:]
+    for h in hists[1:]:
+        if h.axes[1:] != ref_axes:
+            raise ValueError("all histograms must share identical non-Sample axes")
+
+    csamples = []
+    for h in hists:
+        csamples += list(h.axes[0])
+    if len(set(csamples)) != len(csamples):
+        raise ValueError(f"duplicate sample names across inputs: {csamples}")
+
+    reth = Hist(
+        hist.axis.StrCategory(csamples, name=hists[0].axes[0].name),
+        *ref_axes,
+        storage=hists[0].storage_type(),
+    )
+    for h in hists:
+        for sample in h.axes[0]:
+            reth.view(flow=True)[get_key_index(reth, sample), ...] = h[sample, ...].view(flow=True)
+
+    return reth
+
+
+def align_sample_axis(h: Hist, order: list[str], fill_missing: bool = False) -> Hist:
+    """Return a copy of ``h`` with its first (``Sample``) axis reordered to ``order``.
+
+    Useful for making histograms whose Sample axes hold the same labels in a different
+    order (a reprocessed year), or a different set (a year missing some samples),
+    mergeable with ``+`` / :func:`sum`. If ``fill_missing`` is True, labels in
+    ``order`` absent from ``h`` are created as empty (zero) bins; otherwise a missing
+    label raises ``ValueError``.
+    """
+    labels = set(h.axes[0])
+    if not fill_missing:
+        missing = [sample for sample in order if sample not in labels]
+        if missing:
+            raise ValueError(f"cannot align: samples not present in histogram: {missing}")
+
+    reth = Hist(
+        hist.axis.StrCategory(order, name=h.axes[0].name),
+        *h.axes[1:],
+        storage=h.storage_type(),
+    )
+    for sample in order:
+        if sample in labels:
+            reth.view(flow=True)[get_key_index(reth, sample), ...] = h[sample, ...].view(flow=True)
+
+    return reth
+
+
 def getParticles(particle_list, particle_type):
     """
     Finds particles in `particle_list` of type `particle_type`

--- a/tests/test_hist_utils.py
+++ b/tests/test_hist_utils.py
@@ -1,0 +1,159 @@
+"""Unit tests for the generic histogram helpers migrated out of
+``CombineTemplates.ipynb`` (``rename_sample_axis`` and ``combine_hists``)."""
+
+from __future__ import annotations
+
+import hist
+import numpy as np
+import pytest
+from hist import Hist
+
+from HH4b.utils import align_sample_axis, combine_hists, rename_sample_axis
+
+
+def _mk(samples, base=0.0, nbins=4):
+    """Build a (Sample x mass) weight-storage hist with deterministic content.
+
+    Sample ``i`` gets values ``base + i + arange(nbins)`` and variances at half
+    that, so every sample/bin is distinguishable and sums are easy to predict.
+    """
+    h = Hist(
+        hist.axis.StrCategory(samples, name="Sample"),
+        hist.axis.Regular(nbins, 0, nbins, name="H2PNetMass"),
+        storage="weight",
+    )
+    view = h.view()
+    for i in range(len(samples)):
+        vals = base + i + np.arange(nbins, dtype=float)
+        view["value"][i, :] = vals
+        view["variance"][i, :] = vals * 0.5
+    return h
+
+
+# --------------------------------------------------------------------------- #
+# rename_sample_axis
+# --------------------------------------------------------------------------- #
+def test_rename_sample_axis_appends_suffix():
+    h = _mk(["hh4b", "ttbar"], base=10)
+    r = rename_sample_axis(h, "_JMS_up")
+    assert list(r.axes[0]) == ["hh4b_JMS_up", "ttbar_JMS_up"]
+
+
+def test_rename_sample_axis_preserves_values_and_variances():
+    h = _mk(["hh4b", "ttbar"], base=10)
+    r = rename_sample_axis(h, "_JMS_up")
+    np.testing.assert_array_equal(r["hh4b_JMS_up", :].values(), h["hh4b", :].values())
+    np.testing.assert_array_equal(r["ttbar_JMS_up", :].values(), h["ttbar", :].values())
+    np.testing.assert_array_equal(r["hh4b_JMS_up", :].variances(), h["hh4b", :].variances())
+
+
+def test_rename_sample_axis_keeps_other_axes_and_flow():
+    h = _mk(["hh4b"], base=3)
+    r = rename_sample_axis(h, "_x")
+    assert r.axes[1].name == h.axes[1].name
+    assert r.axes[1].size == h.axes[1].size
+    # flow bins carried through unchanged
+    assert r.view(flow=True).shape == h.view(flow=True).shape
+
+
+def test_rename_sample_axis_does_not_mutate_input():
+    h = _mk(["hh4b", "ttbar"], base=10)
+    rename_sample_axis(h, "_JMS_up")
+    assert list(h.axes[0]) == ["hh4b", "ttbar"]
+
+
+# --------------------------------------------------------------------------- #
+# combine_hists
+# --------------------------------------------------------------------------- #
+def test_combine_hists_concatenates_sample_axis_in_order():
+    h1 = _mk(["hh4b", "ttbar"], base=0)
+    h2 = _mk(["hh4b_JMS_up", "ttbar_JMS_up"], base=100)
+    c = combine_hists(h1, h2)
+    assert list(c.axes[0]) == ["hh4b", "ttbar", "hh4b_JMS_up", "ttbar_JMS_up"]
+
+
+def test_combine_hists_copies_values_and_variances():
+    h1 = _mk(["hh4b", "ttbar"], base=0)
+    h2 = _mk(["hh4b_JMS_up"], base=100)
+    c = combine_hists(h1, h2)
+    np.testing.assert_array_equal(c["hh4b", :].values(), h1["hh4b", :].values())
+    np.testing.assert_array_equal(c["ttbar", :].variances(), h1["ttbar", :].variances())
+    np.testing.assert_array_equal(c["hh4b_JMS_up", :].values(), h2["hh4b_JMS_up", :].values())
+    np.testing.assert_array_equal(c["hh4b_JMS_up", :].variances(), h2["hh4b_JMS_up", :].variances())
+
+
+def test_combine_hists_preserves_mass_flow_bins():
+    h1 = _mk(["hh4b"], base=0)
+    # stuff the mass-overflow bin of sample 0 (axis-0 index 1 is the StrCategory
+    # "other" overflow, which combine_hists intentionally does not carry per-sample)
+    h1.view(flow=True)["value"][0, -1] = 42.0
+    c = combine_hists(h1)
+    assert c.view(flow=True)["value"][0, -1] == 42.0
+
+
+def test_combine_hists_single_input_roundtrips():
+    h1 = _mk(["hh4b", "ttbar"], base=5)
+    c = combine_hists(h1)
+    assert list(c.axes[0]) == ["hh4b", "ttbar"]
+    np.testing.assert_array_equal(c["ttbar", :].values(), h1["ttbar", :].values())
+
+
+def test_combine_hists_rejects_duplicate_samples():
+    h1 = _mk(["hh4b", "ttbar"], base=0)
+    h2 = _mk(["ttbar", "qcd"], base=1)  # 'ttbar' duplicated across inputs
+    with pytest.raises(ValueError, match="duplicate"):
+        combine_hists(h1, h2)
+
+
+def test_combine_hists_rejects_mismatched_non_sample_axes():
+    h1 = _mk(["hh4b"], base=0, nbins=4)
+    h2 = _mk(["ttbar"], base=0, nbins=8)  # different mass binning
+    with pytest.raises(ValueError, match="non-Sample axes"):
+        combine_hists(h1, h2)
+
+
+def test_combine_hists_requires_at_least_one_hist():
+    with pytest.raises(ValueError, match="at least one"):
+        combine_hists()
+
+
+# --------------------------------------------------------------------------- #
+# align_sample_axis
+# --------------------------------------------------------------------------- #
+def test_align_sample_axis_reorders_to_requested_order():
+    h = _mk(["hh4b", "ttbar", "qcd"], base=10)
+    r = align_sample_axis(h, ["qcd", "hh4b", "ttbar"])
+    assert list(r.axes[0]) == ["qcd", "hh4b", "ttbar"]
+
+
+def test_align_sample_axis_preserves_per_sample_content():
+    h = _mk(["hh4b", "ttbar", "qcd"], base=10)
+    r = align_sample_axis(h, ["qcd", "hh4b", "ttbar"])
+    for sample in ["hh4b", "ttbar", "qcd"]:
+        np.testing.assert_array_equal(r[sample, :].values(), h[sample, :].values())
+        np.testing.assert_array_equal(r[sample, :].variances(), h[sample, :].variances())
+
+
+def test_align_sample_axis_makes_reordered_hists_summable():
+    h1 = _mk(["hh4b", "ttbar", "qcd"], base=0)
+    h2 = _mk(["qcd", "hh4b", "ttbar"], base=100)  # same set, different order
+    aligned = align_sample_axis(h2, list(h1.axes[0]))
+    total = h1 + aligned  # raises without alignment: Sample axes in different order
+    np.testing.assert_array_equal(
+        total["hh4b", :].values(), h1["hh4b", :].values() + h2["hh4b", :].values()
+    )
+
+
+def test_align_sample_axis_rejects_missing_label():
+    h = _mk(["hh4b", "ttbar"], base=0)
+    with pytest.raises((KeyError, ValueError)):
+        align_sample_axis(h, ["hh4b", "ttbar", "qcd"])
+
+
+def test_align_sample_axis_fill_missing_zero_fills_absent_samples():
+    h = _mk(["hh4b", "ttbar"], base=5)
+    r = align_sample_axis(h, ["hh4b", "ttbar", "qcd"], fill_missing=True)
+    assert list(r.axes[0]) == ["hh4b", "ttbar", "qcd"]
+    np.testing.assert_array_equal(r["hh4b", :].values(), h["hh4b", :].values())
+    np.testing.assert_array_equal(r["qcd", :].values(), np.zeros(4))
+    np.testing.assert_array_equal(r["qcd", :].variances(), np.zeros(4))

--- a/tests/test_template_shapes.py
+++ b/tests/test_template_shapes.py
@@ -1,0 +1,410 @@
+"""Unit tests for the shape-systematic infrastructure migrated out of
+``CombineTemplates.ipynb``.
+
+Covers the cross-year template combination + weight-shift/JEC-JMSR dispatch
+(``combine_templates``), the systematic enumeration (``get_shape_systematics``),
+the smorph JMS/JMR variation helper (``compute_jmsr_variations``), and the
+plotting driver dispatch (``make_shape_plots``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import hist
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from hist import Hist
+
+from HH4b import plotting
+from HH4b.hh_vars import jmsr_values
+from HH4b.postprocessing import (
+    Region,
+    combine_templates,
+    compute_jmsr_variations,
+    get_shape_systematics,
+    get_weight_shifts,
+)
+from HH4b.postprocessing.PlotShapes import (
+    _year_label,
+    default_shape_plot_dir,
+    make_shape_plots,
+)
+from HH4b.utils import Syst, align_sample_axis
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+# compute_jmsr_variations -> smorph -> rhalphalib, which is not installed in the CI extra
+requires_rhalphalib = pytest.mark.skipif(
+    not _module_available("rhalphalib"), reason="rhalphalib not installed"
+)
+
+YEARS = ["2022", "2022EE"]
+BASES = {"2022": 100.0, "2022EE": 200.0}
+REGION = "pass_bin1"
+
+
+def _mk(samples, base=0.0, nbins=4):
+    h = Hist(
+        hist.axis.StrCategory(samples, name="Sample"),
+        hist.axis.Regular(nbins, 0, nbins, name="H2PNetMass"),
+        storage="weight",
+    )
+    view = h.view()
+    for i in range(len(samples)):
+        vals = base + i + np.arange(nbins, dtype=float)
+        view["value"][i, :] = vals
+        view["variance"][i, :] = vals * 0.5
+    return h
+
+
+@pytest.fixture
+def templates():
+    """Synthetic per-year templates mimicking the real pickle structure:
+
+    - nominal region hist carries weight-shift variations as extra Sample
+      categories ``{sample}_trigger_{up,down}``;
+    - JEC/JMSR shifts live in separate ``{region}_{shift}_{up,down}`` hists.
+    """
+    t = {}
+    for year in YEARS:
+        b = BASES[year]
+        t[year] = {
+            REGION: _mk(["hh4b", "ttbar", "hh4b_trigger_up", "hh4b_trigger_down"], base=b),
+            f"{REGION}_JMS_up": _mk(["hh4b", "ttbar"], base=b + 10),
+            f"{REGION}_JMS_down": _mk(["hh4b", "ttbar"], base=b + 20),
+            f"{REGION}_JER_up": _mk(["hh4b", "ttbar"], base=b + 30),
+            f"{REGION}_JER_down": _mk(["hh4b", "ttbar"], base=b + 40),
+            f"{REGION}_JES_up": _mk(["hh4b", "ttbar"], base=b + 50),
+            f"{REGION}_JES_down": _mk(["hh4b", "ttbar"], base=b + 60),
+            f"{REGION}_JMR_up": _mk(["hh4b", "ttbar"], base=b + 70),
+            f"{REGION}_JMR_down": _mk(["hh4b", "ttbar"], base=b + 80),
+        }
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# combine_templates
+# --------------------------------------------------------------------------- #
+def test_combine_templates_nominal_sums_over_years(templates):
+    h = combine_templates(templates, YEARS, REGION)
+    np.testing.assert_array_equal(h["hh4b", :].values(), [300.0, 302.0, 304.0, 306.0])
+    np.testing.assert_array_equal(h["ttbar", :].values(), [302.0, 304.0, 306.0, 308.0])
+
+
+def test_combine_templates_nominal_keeps_weight_shift_samples(templates):
+    h = combine_templates(templates, YEARS, REGION)
+    samples = list(h.axes[0])
+    assert "hh4b_trigger_up" in samples
+    assert "hh4b_trigger_down" in samples
+
+
+def test_combine_templates_weight_shift_returns_summed_nominal(templates):
+    # For weight-based systematics the up/down are baked into the nominal hist,
+    # so the dispatch must NOT try to read separate {region}_trigger_{dir} hists.
+    h = combine_templates(templates, YEARS, REGION, shift="trigger")
+    np.testing.assert_array_equal(h["hh4b_trigger_up", :].values(), [304.0, 306.0, 308.0, 310.0])
+    np.testing.assert_array_equal(h["hh4b", :].values(), [300.0, 302.0, 304.0, 306.0])
+
+
+def test_combine_templates_jmsr_concatenates_shifted_samples(templates):
+    h = combine_templates(templates, YEARS, REGION, shift="JMS")
+    samples = list(h.axes[0])
+    # nominal samples retained ...
+    assert "hh4b" in samples
+    assert "ttbar" in samples
+    # ... plus the renamed JMS up/down categories sigErrRatioPlot looks for
+    assert "hh4b_JMS_up" in samples
+    assert "hh4b_JMS_down" in samples
+
+
+def test_combine_templates_jmsr_values_are_cross_year_sums(templates):
+    h = combine_templates(templates, YEARS, REGION, shift="JMS")
+    np.testing.assert_array_equal(h["hh4b_JMS_up", :].values(), [320.0, 322.0, 324.0, 326.0])
+    np.testing.assert_array_equal(h["hh4b_JMS_down", :].values(), [340.0, 342.0, 344.0, 346.0])
+    # nominal untouched
+    np.testing.assert_array_equal(h["hh4b", :].values(), [300.0, 302.0, 304.0, 306.0])
+
+
+def test_combine_templates_jec_concatenates_shifted_samples(templates):
+    h = combine_templates(templates, YEARS, REGION, shift="JER")
+    samples = list(h.axes[0])
+    assert "hh4b_JER_up" in samples
+    assert "hh4b_JER_down" in samples
+    np.testing.assert_array_equal(h["hh4b_JER_up", :].values(), [360.0, 362.0, 364.0, 366.0])
+
+
+def test_combine_templates_handles_reordered_era(templates):
+    # mimic a reprocessed era whose Sample axis has the same set in a different
+    # order (real case: 2023BPix in the split2024MC templates)
+    h = templates["2022EE"][REGION]
+    reordered = align_sample_axis(h, list(h.axes[0])[::-1])
+    templates["2022EE"][REGION] = reordered
+
+    out = combine_templates(templates, YEARS, REGION)
+    # summed values must be unchanged by the reordering
+    np.testing.assert_array_equal(out["hh4b", :].values(), [300.0, 302.0, 304.0, 306.0])
+    np.testing.assert_array_equal(out["ttbar", :].values(), [302.0, 304.0, 306.0, 308.0])
+
+
+def test_combine_templates_unions_partial_sample_sets(templates):
+    # mimic 2024/2025 missing 'qcd' relative to 2022-2023: one era lacks 'ttbar'
+    templates["2022EE"][REGION] = _mk(["hh4b", "hh4b_trigger_up", "hh4b_trigger_down"], base=200)
+    out = combine_templates(templates, YEARS, REGION)
+    samples = list(out.axes[0])
+    # the sample present in only one era is retained via the union ...
+    assert "ttbar" in samples
+    # ... summing only over the era(s) that have it (2022: base 100, idx 1)
+    np.testing.assert_array_equal(out["ttbar", :].values(), [101.0, 102.0, 103.0, 104.0])
+    # hh4b is present in both eras, so it sums over both
+    np.testing.assert_array_equal(out["hh4b", :].values(), [300.0, 302.0, 304.0, 306.0])
+
+
+def test_combine_templates_preserves_variances(templates):
+    h = combine_templates(templates, YEARS, REGION, shift="JMS")
+    # year-summed variances add: 0.5*(b+ ...) per year
+    expected = 0.5 * np.array([110.0, 111.0, 112.0, 113.0]) + 0.5 * np.array(
+        [210.0, 211.0, 212.0, 213.0]
+    )
+    np.testing.assert_allclose(h["hh4b_JMS_up", :].variances(), expected)
+
+
+# --------------------------------------------------------------------------- #
+# get_shape_systematics
+# --------------------------------------------------------------------------- #
+def test_get_shape_systematics_includes_signal_weight_shifts():
+    ws = get_weight_shifts("glopart-v2", "25Feb5_v13_glopartv2_rawmass")
+    shifts = get_shape_systematics(ws, "hh4b")
+    assert "trigger" in shifts  # applies to signal
+    assert "scale" in shifts  # applies to signal
+    # ttbar-only shifts excluded for a signal sample
+    assert "ttbarSF_pTjj" not in shifts
+
+
+def test_get_shape_systematics_appends_jec_and_jmsr():
+    ws = get_weight_shifts("glopart-v2", "25Feb5_v13_glopartv2_rawmass")
+    shifts = get_shape_systematics(ws, "hh4b")
+    for s in ("JES", "JER", "JMS", "JMR"):
+        assert s in shifts
+
+
+def test_get_shape_systematics_respects_sample_membership():
+    ws = get_weight_shifts("glopart-v2", "25Feb5_v13_glopartv2_rawmass")
+    tshifts = get_shape_systematics(ws, "ttbar")
+    assert "ttbarSF_pTjj" in tshifts
+
+
+def test_get_shape_systematics_can_disable_jec_jmsr():
+    ws = get_weight_shifts("glopart-v2", "25Feb5_v13_glopartv2_rawmass")
+    shifts = get_shape_systematics(ws, "hh4b", include_jec=False, include_jmsr=False)
+    assert not any(s in shifts for s in ("JES", "JER", "JMS", "JMR"))
+
+
+# --------------------------------------------------------------------------- #
+# compute_jmsr_variations (smorph fold of notebook cells 11-14)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def signal_mass_hist():
+    h = Hist(
+        hist.axis.StrCategory(["hh4b"], name="Sample"),
+        hist.axis.Regular(16, 60, 220, name="bbFatJetParTmassVis"),
+        storage="weight",
+    )
+    rng = np.random.default_rng(0)
+    h.fill(Sample="hh4b", bbFatJetParTmassVis=rng.normal(125, 15, 50000))
+    return h["hh4b", :]
+
+
+def _mean(h1d):
+    centers = h1d.axes[0].centers
+    vals = h1d.values()
+    return np.sum(centers * vals) / np.sum(vals)
+
+
+@requires_rhalphalib
+def test_compute_jmsr_variations_returns_five_named_variations(signal_mass_hist):
+    out = compute_jmsr_variations(signal_mass_hist, "hh4b", "2022")
+    assert set(out) == {"nominal", "jms_up", "jms_down", "jmr_up", "jmr_down"}
+
+
+@requires_rhalphalib
+def test_compute_jmsr_variations_keep_binning_and_are_finite(signal_mass_hist):
+    out = compute_jmsr_variations(signal_mass_hist, "hh4b", "2022")
+    for v in out.values():
+        assert v.axes[0].size == signal_mass_hist.axes[0].size
+        assert np.all(np.isfinite(v.values()))
+
+
+@requires_rhalphalib
+def test_compute_jmsr_variations_jms_shifts_mean_monotonically(signal_mass_hist):
+    out = compute_jmsr_variations(signal_mass_hist, "hh4b", "2022")
+    # 2022 JMS: down=1.007 < up=1.014, so the up-scaled mean must exceed the down one
+    assert _mean(out["jms_up"]) > _mean(out["jms_down"])
+
+
+@requires_rhalphalib
+def test_compute_jmsr_variations_conserves_yield(signal_mass_hist):
+    out = compute_jmsr_variations(signal_mass_hist, "hh4b", "2022")
+    nominal_integral = np.sum(signal_mass_hist.values())
+    for v in out.values():
+        np.testing.assert_allclose(np.sum(v.values()), nominal_integral, rtol=0.02)
+
+
+@requires_rhalphalib
+def test_jms_jmr_comparison_plot_writes_pdf(signal_mass_hist, tmp_path):
+    plt.switch_backend("Agg")
+    variations = compute_jmsr_variations(signal_mass_hist, "hh4b", "2022")
+    jms = jmsr_values["bbFatJetParTmassVis"]["JMS"]["2022"]
+    jmr = jmsr_values["bbFatJetParTmassVis"]["JMR"]["2022"]
+
+    plotting.jmsJmrComparisonPlot(
+        variations, jms, jmr, original=signal_mass_hist, plot_dir=tmp_path, name="cmp"
+    )
+    assert (tmp_path / "cmp.pdf").exists()
+
+
+# --------------------------------------------------------------------------- #
+# make_shape_plots (driver dispatch)
+# --------------------------------------------------------------------------- #
+def test_make_shape_plots_calls_plotter_per_region_and_shift(templates, tmp_path, monkeypatch):
+    calls = []
+
+    def _spy(*args, **_kwargs):
+        h, _, wshift, _, title, _, name = args[:7]
+        calls.append(
+            {
+                "samples": list(h.axes[0]),
+                "wshift": wshift,
+                "title": title,
+                "name": name,
+            }
+        )
+
+    monkeypatch.setattr(plotting, "sigErrRatioPlot", _spy)
+
+    weight_shifts = {"trigger": Syst(samples=["hh4b"], label="Trigger")}
+    selection_regions = {REGION: Region(cuts={"Category": [1, 2]}, label="Bin1")}
+
+    make_shape_plots(
+        templates,
+        YEARS,
+        selection_regions,
+        "hh4b",
+        weight_shifts,
+        plot_dir=tmp_path,
+        xlabel="$m_{reg}$ (GeV)",
+        shifts=["trigger", "JMS"],
+    )
+
+    assert len(calls) == 2
+    by_shift = {c["wshift"]: c for c in calls}
+
+    # weight shift: baked-in up/down samples present, label drawn from Syst
+    assert "hh4b_trigger_up" in by_shift["trigger"]["samples"]
+    assert "Trigger" in by_shift["trigger"]["title"]
+    assert by_shift["trigger"]["name"] == f"{REGION}_sig_trigger"
+
+    # JMSR shift: renamed up/down samples present, raw shift name used as label
+    assert "hh4b_JMS_up" in by_shift["JMS"]["samples"]
+    assert "JMS" in by_shift["JMS"]["title"]
+    assert by_shift["JMS"]["name"] == f"{REGION}_sig_JMS"
+
+
+def test_make_shape_plots_skips_jec_jmsr_shift_absent_from_templates(
+    templates, tmp_path, monkeypatch
+):
+    # real template sets do not always carry every JEC/JMSR shift (e.g. no JES)
+    for year in YEARS:
+        del templates[year][f"{REGION}_JES_up"]
+        del templates[year][f"{REGION}_JES_down"]
+
+    seen = []
+    monkeypatch.setattr(plotting, "sigErrRatioPlot", lambda *a, **_: seen.append(a[2]))
+    ws = {"trigger": Syst(samples=["hh4b"], label="Trigger")}
+    sel = {REGION: Region(cuts={"Category": [1, 2]}, label="Bin1")}
+
+    with pytest.warns(UserWarning, match="JES"):
+        make_shape_plots(
+            templates, YEARS, sel, "hh4b", ws, plot_dir=tmp_path, xlabel="m", shifts=["JES", "JMS"]
+        )
+    assert seen == ["JMS"]
+
+
+def test_make_shape_plots_skips_weight_shift_without_baked_samples(
+    templates, tmp_path, monkeypatch
+):
+    seen = []
+    monkeypatch.setattr(plotting, "sigErrRatioPlot", lambda *a, **_: seen.append(a[2]))
+    # 'pdf' is not baked into the synthetic nominal hist
+    ws = {
+        "pdf": Syst(samples=["hh4b"], label="PDF"),
+        "trigger": Syst(samples=["hh4b"], label="Trigger"),
+    }
+    sel = {REGION: Region(cuts={"Category": [1, 2]}, label="Bin1")}
+
+    with pytest.warns(UserWarning, match="pdf"):
+        make_shape_plots(
+            templates,
+            YEARS,
+            sel,
+            "hh4b",
+            ws,
+            plot_dir=tmp_path,
+            xlabel="m",
+            shifts=["pdf", "trigger"],
+        )
+    assert seen == ["trigger"]
+
+
+# --------------------------------------------------------------------------- #
+# output-dir derivation
+# --------------------------------------------------------------------------- #
+def test_year_label_spans_min_to_max():
+    assert _year_label(["2022", "2022EE", "2023", "2023BPix"]) == "2022-2023"
+    assert _year_label(["2022", "2022EE", "2023", "2023BPix", "2024", "2025"]) == "2022-2025"
+
+
+def test_year_label_single_year():
+    assert _year_label(["2024"]) == "2024"
+
+
+def test_default_shape_plot_dir_derives_from_tag_and_repo_root(tmp_path):
+    # fake a standard checkout layout: <root>/src/HH4b + the templates dir
+    root = tmp_path / "HH4b"
+    (root / "src" / "HH4b").mkdir(parents=True)
+    tdir = root / "src" / "HH4b" / "postprocessing" / "templates" / "26Mar10_split2024MC"
+    tdir.mkdir(parents=True)
+
+    out = default_shape_plot_dir(tdir, ["2022", "2022EE", "2023", "2023BPix", "2024", "2025"])
+    expected = root / "plots/PostProcess/26Mar10_split2024MC/Templates/2022-2025/wshifts"
+    assert out == expected
+
+
+def test_make_shape_plots_defaults_to_all_applicable_shifts(templates, tmp_path, monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        plotting, "sigErrRatioPlot", lambda *a, **_: seen.append(a[2])  # wshift positional arg
+    )
+    ws = {"trigger": Syst(samples=["hh4b"], label="Trigger")}
+    selection_regions = {REGION: Region(cuts={"Category": [1, 2]}, label="Bin1")}
+
+    make_shape_plots(
+        templates,
+        YEARS,
+        selection_regions,
+        "hh4b",
+        ws,
+        plot_dir=tmp_path,
+        xlabel="m",
+    )
+    # default enumerates the trigger weight shift plus JEC/JMSR
+    assert "trigger" in seen
+    assert "JMS" in seen
+    assert "JER" in seen


### PR DESCRIPTION
Move the template-combination and systematic shape-plotting logic from CombineTemplates.ipynb into the package, with unit tests.

- utils: combine_hists, rename_sample_axis, align_sample_axis (Sample-axis hist surgery that was inline in the notebook)
- postprocessing: combine_templates (cross-year sum + weight/JEC-JMSR dispatch, tolerant of per-era sample reordering and partial sample sets via union zero-fill, so 2022-2025 combine despite 2024/2025 lacking qcd), get_shape_systematics, shift_available, compute_jmsr_variations (smorph JMS/JMR cross-check, fixed to the current jmsr_values schema)
- plotting: jmsJmrComparisonPlot (3-panel JMS/JMR comparison)
- PlotShapes.py: make_shape_plots driver + CLI; skips systematics absent from a template set; output dir auto-derived from the template-set tag (<repo>/plots/PostProcess/<tag>/Templates/<years>/wshifts)
- CombineTemplates.ipynb: reduced to a thin shim over the new functions
- tests: test_hist_utils.py, test_template_shapes.py
- pyproject: ignore third-party import-time deprecations so the suite imports plotting/postprocessing cleanly under filterwarnings=error