### PR TITLE
Add transformer-based neural-network discriminant (neural_network subpackage)

### DIFF
--- a/src/HH4b/neural_network/README.md
+++ b/src/HH4b/neural_network/README.md
@@ -1,0 +1,88 @@
+# Neural Network — Transformer Jet Classifier
+
+A transformer-based multi-class classifier used as an alternative discriminant to the XGBoost
+BDT. Each input group (event-level, AK8 Higgs jets, AK4 away-jets, VBF jets) is embedded
+separately into tokens; a learned `[CLS]` token is prepended; a `TransformerEncoder` processes
+the sequence; the pooled representation (`CLS ⊕ masked-mean`) is classified by an MLP head into
+per-class softmax scores. Training is config-driven (YAML), with equalize-class weights consistent
+with `TrainBDT.py`.
+
+## Pipeline (run order)
+
+```
+skimmer parquet
+   │  prepare_data.py   (cuts + trigger + BDT-input vars, 80/10/10 split, class weights)
+   ▼
+{train,val,test,all}/<year>_<class>.parquet  +  class_weights_<year>.json
+   │  train.py --config configs/<x>.yaml
+   ▼
+checkpoints/*.pt  +  roc_curves/*  +  scores/epoch_<N>/<split>/<class>.npz
+   │  train.py ... --evaluation-only --eval-epoch best   (inference-only re-eval)
+   ▼
+scores/*.npz  →  ROC / downstream comparison
+```
+
+## Files
+
+| file | what it does | how to run |
+|---|---|---|
+| **`prepare_data.py`** | Loads skimmer parquet, applies the same kinematic + trigger cuts as `TrainBDT.py`, computes BDT input features (`--bdt-config`), cleans NaN/outliers → `-99999`, splits 80/10/10, writes per-class parquet + `class_weights_<year>.json`. | **CLI** — `python prepare_data.py` (all args defaulted). |
+| **`train.py`** | Main entry point. Builds dataloaders/model/loss/optimizer/scheduler from a YAML config; runs the train/val loop with early stopping + checkpointing; computes ROC; writes per-split softmax scores. Also a library (`build_model`, `run_epoch`, … reused for extra-sample eval). | **CLI** — `python train.py --config configs/<x>.yaml` |
+| `models/classifier.py` | `JetClassifier`: per-group embedding → `[CLS]` + tokens → `TransformerEncoder` → `CLS ⊕ masked-mean` pool → MLP head → logits. | library (built in `train.py:build_model`) |
+| `models/transformer.py` | `TransformerEncoder` / pre-norm `TransformerEncoderLayer` + `RMSNorm`, `SwiGLUFFN`, `LayerScale`, `DropPath`, register tokens. | library |
+| `models/embedding.py` | `InputEmbedding` (linear-projects continuous + sums discrete `nn.Embedding` + LayerNorm, zeroes invalid tokens). | library |
+| `utils/dataset.py` | `JetDataset` (numpy-backed, low worker memory), `jet_collate_fn` (batches raw tensors + applies feature transforms in one vectorized pass), `GroupConfig`. | library |
+| `utils/roc.py` | `compute_roc_metrics` / `compute_roc_per_signal` (weighted AUC + sig-eff@bkg-eff), `save_roc_plot`, `ScoreAccumulator`. | library |
+| `utils/feature_transform.py` | `FeatureTransform`: `normal` (z-score), `log_normal`, `min_max`, `digitize` (→ discrete embedding indices). | library |
+| `utils/scheduler.py` | `get_scheduler` — StepLR / Cosine / SequentialLR (+ warmup), LR-resync on resume. | library |
+| `utils/ckpt.py` | Checkpoint save/load + `resolve_output_dir` / `get_checkpoints_path` with `${name}`/`${epoch_num}` expansion. | library |
+| `utils/logger.py` | Colored console + file logger (`LOGGER`). | library |
+| `utils/__init__.py` | Re-exports the public utils API (`from utils import …`). | library |
+| `configs/*.yaml` | Run configs (dataset, training, inputs, architecture). See below. | — |
+
+## How to run
+
+```bash
+# 1) prepare data (defaults: --tag nanov15_20251202_v15_signal, --years 2024, --bdt-config v13_glopartv3)
+python prepare_data.py --years 2022 2022EE 2023 2023BPix 2024
+
+# 2) train
+python train.py --config configs/transformer.yaml            # add --use-wandb for W&B logging
+
+# multi-GPU (torchrun)
+torchrun --nproc_per_node 4 train.py --config configs/transformer.yaml --log-file logs/run.log
+
+# 3) inference-only (regenerate scores + ROC from the best checkpoint)
+python train.py --config configs/transformer.yaml --evaluation-only --eval-epoch best
+```
+
+Key `train.py` flags: `--config/-c` (**required**), `--use-wandb`, `--evaluation-only`,
+`--eval-epoch <int|best>`, `--log-file`, `--log-level`.
+
+## Config YAML
+
+A config defines four blocks:
+- **`dataset`** — `dir`, `file_pattern` (e.g. `${split}/${year}_${class}.parquet`), `years`,
+  `weight_key: finalWeight`, and `classes` with per-class `cls_weights`.
+- **`training`** — `loss` (`focal`/`cross_entropy`), `use_weights` (per loss/acc/roc), `batch_size`,
+  `num_epochs`, `patience`, `max_grad_norm`, `optimizer`, `scheduler`, `roc_groups`.
+- **`inputs`** — the input groups (`event`, `bbFatJet1`, `bbFatJet2`, `AK4JetAway`, `VBFJet`), each
+  with `idx`, `mask`, and `continuous_features` / `discrete_features` (+ per-feature `transform`).
+- **`architecture`** — `encoder` (`dim`, `num_layers`, `num_heads`, `activation`, `norm`, …) + `head`.
+
+`configs/config.yaml` is the committed template. The base experiment `transformer.yaml`
+(4 classes: `hh4b`, `vbfhh4b-k2v0`, `qcd`, `ttbar`) uses `dim=128, num_layers=4, num_heads=8`,
+SwiGLU/RMSNorm, a 2-layer MLP head, `AdamW`, `batch_size=50000`, cosine warmup→decay over 500 epochs.
+
+## Conventions & notes
+
+- **LR scaling:** `lr = 1e-4` at `batch_size = 1000`, scaled **linearly** with batch size (e.g.
+  `batch_size=50000` → `lr=5e-3`). Encoded per-config in `optimizer.kwargs.lr`, not auto-computed.
+- **Class weights:** signal `cls_weights` are large (≈130k `hh4b`, ≈23k `vbfhh4b-k2v0`) so total
+  signal weight balances total background; `qcd`/`ttbar` = 1.0 (matches `TrainBDT.py`).
+- **Outputs** (under the config's `output_dir`): `checkpoints/checkpoint_epoch_{N,best}.pt`,
+  `roc_curves/roc_<split>_epoch_<N>.{png,pdf}` + `eval_metrics_*.json`,
+  `scores/epoch_<N>/<split>/<class>.npz` (softmax scores + weights).
+- **Cadence:** during training, scores/ROC are collected only on new-best epochs; a full
+  train/val/test evaluation runs at end-of-training and in `--evaluation-only` mode.
+- Multi-GPU uses HuggingFace `accelerate` (`dispatch_batches=True`) + bf16 when enabled.

--- a/src/HH4b/neural_network/configs/config.yaml
+++ b/src/HH4b/neural_network/configs/config.yaml
@@ -1,0 +1,256 @@
+name: transformer-allmasses-noptop
+
+use_accelerate: true
+use_bf16: false
+float32_matmul_precision: "high"
+
+output_dir: "/path/to/output/${name}"
+dataset:
+  splits: ["train", "val", "test"]
+  years: ["2024"]
+  dir: "/path/to/dataset"
+  file_pattern: "${split}/${year}_${class}.parquet"
+  weight_key: "finalWeight"
+  classes:
+    # Calculated based on sum weights to balance background (qcd + ttbar) and signal (hh4b + vbfhh4b)
+    # based on https://github.com/LPC-HH/HH4b/blob/5d1d87b9f6ba3b74f3700623b7ec9d0706a1d519/src/HH4b/boosted/TrainBDT.py#L249
+    # Scaled down by 1e-5 to avoid numerical issues with large weights
+    - name: qcd
+      cls_weights: 1.e-5
+    - name: ttbar
+      cls_weights: 1.e-5
+    - name: hh4b
+      cls_weights: 2.3616065278539775
+    - name: vbfhh4b
+      cls_weights: 346.6203536424499
+
+training:
+  loss: "FocalLoss"  # FocalLoss or CrossEntropyLoss
+  batch_size: 5000
+  patience: 10
+  num_epochs: 500
+  optimizer:
+    type: AdamW
+    kwargs:
+      lr: 5.e-3
+  scheduler:
+    name: "SequentialLR"
+    params:
+      milestones: [20]
+      schedulers:
+        - name: "CosineScheduler"
+          params:
+            base_value: 0.0
+            final_value: 1.0
+            total_iters: 20
+        - name: "CosineScheduler"
+          params:
+            base_value: 1.0
+            final_value: 1.e-2
+            total_iters: 480
+
+inputs:
+  # event-level info
+  - name: event
+    idx: [0]
+    continuous_features:
+      - name: MET_pt
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 3.9
+            std: 0.75
+      - name: ht
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 6.9
+            std: 0.35
+      - name: nJets
+        transform: normal
+        kwargs:
+            mean: 7.0
+            std: 2.0
+
+  # AK8 jet 1
+  - name: bbFatJet1
+    idx: [0]
+    mask:
+      - name: bbFatJetPt
+        min: 0
+        max: "inf"
+    continuous_features:
+      - name: bbFatJetPt
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 6.0
+            std: 0.35
+      - name: bbFatJetMass
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.6
+            std: 0.5
+      - name: bbFatJetMsd
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.7
+            std: 0.5
+      - name: bbFatJetPNetMass
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.8
+            std: 0.4
+      - name: bbFatJetParT3massGeneric
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.7
+            std: 0.4
+      - name: bbFatJetParT3massX2p
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.5
+            std: 0.6
+      - name: bbFatJetEta
+        transform:
+          type: normal
+          kwargs:
+            mean: 0.0
+            std: 1.1
+      - name: bbFatJetPhi
+        transform:
+          type: min_max
+          kwargs:
+            min_val: -3.141592653589793
+            max_val: 3.141592653589793
+      # - name: bbFatJetParT3PTopbWev
+      # - name: bbFatJetParT3PTopbWmv
+      # - name: bbFatJetParT3PTopbWq
+      # - name: bbFatJetParT3PTopbWqq
+      # - name: bbFatJetParT3PTopbWtauhv
+    discrete_features:
+      - name: bbFatJetParT3TXbb
+        transform:
+          type: digitize
+          kwargs:
+            bins: [0.8, 0.9, 0.94, 0.97, 0.99]
+
+  # AK8 jet 2: no mass or TXbb info
+  - name: bbFatJet2
+    idx: [1]
+    mask:
+      - name: bbFatJetPt
+        min: 0
+        max: "inf"
+    continuous_features:
+      - name: bbFatJetPt
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 6.0
+            std: 0.35
+      - name: bbFatJetEta
+        transform:
+          type: normal
+          kwargs:
+            mean: 0.0
+            std: 1.1
+      - name: bbFatJetPhi
+        transform:
+          type: min_max
+          kwargs:
+            min_val: -3.141592653589793
+            max_val: 3.141592653589793
+
+  # AK4 jets
+  - name: AK4JetAway
+    mask:
+      - name: AK4JetAwayPt
+        min: 0
+        max: "inf"
+    idx: [0, 1]
+    continuous_features:
+      - name: AK4JetAwayPt
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.2
+            std: 0.75
+      - name: AK4JetAwayMass
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 2.2
+            std: 0.6
+      - name: AK4JetAwayEta
+        transform:
+          type: normal
+          kwargs:
+            mean: 0.0
+            std: 1.5
+      - name: AK4JetAwayPhi
+        transform:
+          type: min_max
+          kwargs:
+            min_val: -3.141592653589793
+            max_val: 3.141592653589793
+
+  # VBF jets
+  - name: VBFJet
+    mask:
+      - name: VBFJetPt
+        min: 0
+        max: "inf"
+    idx: [0, 1]
+    continuous_features:
+      - name: VBFJetPt
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 4.15
+            std: 0.8
+      - name: VBFJetMass
+        transform:
+          type: log_normal
+          kwargs:
+            mean: 2.15
+            std: 0.7
+      - name: VBFJetEta
+        transform:
+          type: normal
+          kwargs:
+            mean: 0.0
+            std: 2.5
+      - name: VBFJetPhi
+        transform:
+          type: min_max
+          kwargs:
+            min_val: -3.141592653589793
+            max_val: 3.141592653589793
+
+architecture:
+  encoder:
+    dim: 512
+    num_layers: 8
+    num_heads: 16
+    activation: "SwiGLU"
+    norm: "RMSNorm"
+    layer_scale_init: 1.0
+    num_registers: 4
+    mlp_ratio: 4
+    qkv_bias: true
+    attention_dropout: 0.0
+    norm_eps: 1.e-6
+    apply_final_norm: true
+    apply_embedding_norm: false
+  head:
+    mlp_hidden_dim: 4096
+    activation: "GELU"
+    num_hidden_layers: 2
+    batch_norm: true
+    dropout: 0.1

--- a/src/HH4b/neural_network/models/__init__.py
+++ b/src/HH4b/neural_network/models/__init__.py
@@ -1,0 +1,6 @@
+# ruff: noqa: F401
+from __future__ import annotations
+
+from .classifier import JetClassifier, build_mlp_head
+from .embedding import DiscreteFeatureEmbedding, InputEmbedding
+from .transformer import TransformerEncoder

--- a/src/HH4b/neural_network/models/classifier.py
+++ b/src/HH4b/neural_network/models/classifier.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .transformer import TransformerEncoder
+
+
+class JetClassifier(nn.Module):
+    """Jet classifier that combines per-group embeddings, a transformer encoder,
+    and a classification head.
+
+    Architecture:
+        1. Embed each input group independently → (B, N_i, dim)
+        2. Concatenate all groups along the token axis → (B, N_total, dim)
+        3. Prepend a learned [CLS] token → (B, 1 + N_total, dim)
+        4. Run through TransformerEncoder (with combined key-padding mask)
+        5. Pool: CLS output  ⊕  masked mean over non-CLS tokens → (B, 2*dim)
+        6. Head MLP → (B, num_classes)
+
+    Args:
+        embeddings:  nn.ModuleDict mapping input-group name → InputEmbedding.
+                     Each InputEmbedding must accept the group's batch dict and
+                     return (tokens: Tensor(B, N_i, dim), mask: Tensor(B, N_i))
+                     where mask is True for *invalid* (padded) tokens.
+        encoder:     TransformerEncoder instance.
+        head:        MLP that maps (B, 2*dim) → (B, num_classes).
+        dim:         Model dimension (must match encoder & embeddings).
+    """
+
+    def __init__(
+        self,
+        embeddings: nn.ModuleDict,
+        encoder: TransformerEncoder,
+        head: nn.Module,
+        dim: int,
+        use_type_embed: bool = False,
+    ):
+        super().__init__()
+        self.embeddings = embeddings
+        self.encoder = encoder
+        self.head = head
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, dim))
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+
+        self.use_type_embed = use_type_embed
+        if use_type_embed:
+            self.type_embed = nn.Embedding(len(embeddings), dim)
+            nn.init.trunc_normal_(self.type_embed.weight, std=0.02)
+
+    def forward(self, batch: dict[str, dict[str, torch.Tensor]]) -> torch.Tensor:
+        """
+        Args:
+            batch: dict mapping group name → dict with keys
+                   'continuous' (B, N_i, D_cont), 'discrete' (B, N_i, D_disc),
+                   and optionally 'mask' (B, N_i) bool (True = invalid).
+
+        Returns:
+            logits: (B, num_classes)
+        """
+        tokens_list = []
+        masks_list = []
+
+        for i, (name, embedding) in enumerate(self.embeddings.items()):
+            tokens, mask = embedding(batch[name])  # (B, N_i, dim), (B, N_i)
+            if self.use_type_embed:
+                tokens = tokens + self.type_embed.weight[i]  # broadcast (dim,) over (B, N_i, dim)
+            tokens_list.append(tokens)
+            masks_list.append(mask)
+
+        # (B, N_total, dim)  &  (B, N_total)
+        x = torch.cat(tokens_list, dim=1)
+        mask = torch.cat(masks_list, dim=1)
+
+        B = x.size(0)
+
+        # Prepend [CLS]: always valid → False in key_padding_mask
+        cls = self.cls_token.expand(B, -1, -1)  # (B, 1, dim)
+        cls_mask = torch.zeros(B, 1, dtype=torch.bool, device=x.device)
+
+        x = torch.cat([cls, x], dim=1)  # (B, 1+N_total, dim)
+        mask = torch.cat([cls_mask, mask], dim=1)  # (B, 1+N_total)
+
+        # Encode
+        x = self.encoder(x, key_padding_mask=mask)  # (B, 1+N_total, dim)
+
+        # Pool ----------------------------------------------------------------
+        cls_out = x[:, 0]  # (B, dim)
+
+        # Masked mean over non-CLS tokens (mask: True = invalid → exclude)
+        token_out = x[:, 1:]  # (B, N_total, dim)
+        valid_mask = ~mask[:, 1:]  # (B, N_total)  True = valid
+        token_out = token_out * valid_mask.unsqueeze(-1).float()
+        denom = valid_mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+        mean_out = token_out.sum(dim=1) / denom  # (B, dim)
+
+        pooled = torch.cat([cls_out, mean_out], dim=-1)  # (B, 2*dim)
+
+        return self.head(pooled)  # (B, num_classes)
+
+
+def build_mlp_head(
+    in_dim: int,
+    num_classes: int,
+    hidden_dim: list[int] | None = None,
+    num_hidden_layers: int = 1,
+    batch_norm: bool = False,
+    dropout: float = 0.0,
+) -> nn.Sequential:
+    dims = hidden_dim if hidden_dim is not None else [in_dim] * num_hidden_layers
+    layers: list[nn.Module] = []
+    current_dim = in_dim
+    use_dropout = dropout > 0.0
+    for h in dims:
+        layers.append(nn.Linear(current_dim, h))
+        if batch_norm:
+            layers.append(nn.BatchNorm1d(h))
+        layers.append(nn.GELU())
+        if use_dropout:
+            layers.append(nn.Dropout(dropout))
+        current_dim = h
+    layers.append(nn.Linear(current_dim, num_classes))
+    return nn.Sequential(*layers)

--- a/src/HH4b/neural_network/models/embedding.py
+++ b/src/HH4b/neural_network/models/embedding.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class DiscreteFeatureEmbedding(nn.Module):
+    """Embedding lookup for one discrete (digitized) feature.
+
+    Args:
+        num_bins:   Number of bins output by digitize (len(bins) + 1).
+        dim:        Output embedding dimension.
+    """
+
+    def __init__(self, num_bins: int, dim: int):
+        super().__init__()
+        self.embedding = nn.Embedding(num_bins, dim)
+        nn.init.trunc_normal_(self.embedding.weight, std=0.02)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: (B, N) long tensor of bin indices.
+        Returns:
+            (B, N, dim)
+        """
+        return self.embedding(x)
+
+
+class InputEmbedding(nn.Module):
+    """Embeds one input group (e.g. bbFatJet0, AK4JetAway) into (B, N, dim).
+
+    Processing:
+        1. Project continuous features linearly: (B, N, D_cont) → (B, N, dim)
+        2. For each discrete feature, look up embedding: (B, N) → (B, N, dim)
+        3. Sum all embeddings (continuous projection + each discrete embedding)
+        4. Apply LayerNorm
+        5. Return tokens (B, N, dim) and validity mask (B, N)
+
+    The mask (True = invalid) is derived from the raw continuous feature values
+    BEFORE transformation, using the configured min/max bounds per mask field.
+
+    Args:
+        n_continuous:       Number of continuous input features (D_cont).
+        dim:                Model embedding dimension.
+        discrete_num_bins:  List of num_bins per discrete feature, in order.
+        dropout:            Dropout applied after summing embeddings.
+    """
+
+    def __init__(
+        self,
+        n_continuous: int,
+        dim: int,
+        discrete_num_bins: list[int] | None = None,
+        dropout: float = 0.0,
+    ):
+        super().__init__()
+
+        self.continuous_proj = nn.Linear(n_continuous, dim) if n_continuous > 0 else None
+
+        discrete_num_bins = discrete_num_bins or []
+        self.discrete_embeddings = nn.ModuleList(
+            [DiscreteFeatureEmbedding(num_bins, dim) for num_bins in discrete_num_bins]
+        )
+
+        self.norm = nn.LayerNorm(dim)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        group: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Args:
+            group: dict with keys:
+                'continuous'  - (B, N, D_cont) float, already transformed
+                'discrete'    - (B, N, D_disc) long, one column per discrete feature
+                                (may be absent if no discrete features)
+                'mask'        - (B, N) bool, True = invalid/padded token
+                                (may be absent if no mask defined)
+
+        Returns:
+            tokens: (B, N, dim)
+            mask:   (B, N) bool — True = invalid
+        """
+        B, N = None, None
+
+        # --- Continuous projection ---
+        out = None
+        if "continuous" in group and self.continuous_proj is not None:
+            cont = group["continuous"]  # (B, N, D_cont)
+            B, N, _ = cont.shape
+            out = self.continuous_proj(cont)  # (B, N, dim)
+
+        # --- Discrete embeddings (additive) ---
+        if "discrete" in group and len(self.discrete_embeddings) > 0:
+            disc = group["discrete"]  # (B, N, D_disc)
+            if B is None:
+                B, N, _ = disc.shape
+            for i, emb in enumerate(self.discrete_embeddings):
+                d = emb(disc[..., i])  # (B, N, dim)
+                out = d if out is None else out + d
+
+        if out is None:
+            raise ValueError("InputEmbedding received no continuous or discrete features.")
+
+        out = self.drop(self.norm(out))  # (B, N, dim)
+
+        # --- Mask ---
+        if "mask" in group:
+            mask = group["mask"]  # (B, N) bool, True = invalid
+        else:
+            mask = torch.zeros(B, N, dtype=torch.bool, device=out.device)
+
+        # Zero out embeddings for invalid tokens so they don't carry signal
+        out = out * (~mask).unsqueeze(-1).float()
+
+        return out, mask

--- a/src/HH4b/neural_network/models/transformer.py
+++ b/src/HH4b/neural_network/models/transformer.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class RMSNorm(nn.Module):
+    """Root Mean Square Layer Normalization."""
+
+    def __init__(self, dim: int, eps: float = 1e-8):
+        super().__init__()
+        self.eps = eps
+        self.scale = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        rms = x.pow(2).mean(dim=-1, keepdim=True).add(self.eps).sqrt()
+        return self.scale * x / rms
+
+
+def get_norm(norm: Literal["LayerNorm", "RMSNorm"], dim: int, eps: float = 1e-5) -> nn.Module:
+    if norm == "RMSNorm":
+        return RMSNorm(dim, eps=eps)
+    return nn.LayerNorm(dim, eps=eps)
+
+
+class FFN(nn.Module):
+    """Standard two-layer FFN with GELU."""
+
+    def __init__(self, dim: int, ffn_dim: int, dropout: float = 0.0):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim, ffn_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(ffn_dim, dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class SwiGLUFFN(nn.Module):
+    """SwiGLU FFN: (x W1) * SiLU(x W2) -> W3.
+
+    ffn_dim is the inner gate dimension (typically 4/3 * dim to keep param count
+    comparable to a standard 4*dim FFN).
+    """
+
+    def __init__(self, dim: int, ffn_dim: int, dropout: float = 0.0):
+        super().__init__()
+        self.w1 = nn.Linear(dim, ffn_dim, bias=False)
+        self.w2 = nn.Linear(dim, ffn_dim, bias=False)
+        self.w3 = nn.Linear(ffn_dim, dim, bias=False)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.drop(self.w3(self.w1(x) * F.silu(self.w2(x))))
+
+
+class LayerScale(nn.Module):
+    """Per-channel learnable scalar applied to residual branch."""
+
+    def __init__(self, dim: int, init_value: float = 1e-4):
+        super().__init__()
+        self.gamma = nn.Parameter(torch.full((dim,), init_value))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.gamma * x
+
+
+class DropPath(nn.Module):
+    """Stochastic depth: randomly drops entire residual branches during training.
+
+    Each sample in the batch independently survives with probability ``1 - drop_prob``.
+    At test time the module is an identity.
+    """
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.drop_prob == 0.0 or not self.training:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        # (B, 1, 1) mask so entire token sequence is kept or dropped per sample
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        mask = torch.rand(shape, dtype=x.dtype, device=x.device) < keep_prob
+        return x * mask / keep_prob
+
+
+class TransformerEncoderLayer(nn.Module):
+    """Pre-norm transformer encoder layer.
+
+    Args:
+        dim:              Model dimension.
+        num_heads:        Number of attention heads.
+        ffn_dim:          Inner FFN dimension.
+        activation:       'GELU' or 'SwiGLU'.
+        norm:             'LayerNorm' or 'RMSNorm'.
+        layer_scale_init: Init value for LayerScale (None to disable).
+        drop_path:        Drop path (stochastic depth) rate for this layer.
+        qkv_bias:         Whether to use bias in QKV projections.
+        attention_dropout: Dropout on attention weights.
+        norm_eps:         Epsilon for norm layers.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        ffn_dim: int,
+        activation: Literal["GELU", "SwiGLU"] = "SwiGLU",
+        norm: Literal["LayerNorm", "RMSNorm"] = "LayerNorm",
+        layer_scale_init: float | None = 1e-4,
+        drop_path: float = 0.0,
+        qkv_bias: bool = True,
+        attention_dropout: float = 0.0,
+        norm_eps: float = 1e-5,
+    ):
+        super().__init__()
+
+        self.norm1 = get_norm(norm, dim, eps=norm_eps)
+        self.norm2 = get_norm(norm, dim, eps=norm_eps)
+
+        self.attn = nn.MultiheadAttention(
+            embed_dim=dim,
+            num_heads=num_heads,
+            dropout=attention_dropout,
+            bias=qkv_bias,
+            batch_first=True,
+        )
+
+        ffn_cls = SwiGLUFFN if activation == "SwiGLU" else FFN
+        self.ffn = ffn_cls(dim, ffn_dim)
+
+        self.ls1 = (
+            LayerScale(dim, layer_scale_init) if layer_scale_init is not None else nn.Identity()
+        )
+        self.ls2 = (
+            LayerScale(dim, layer_scale_init) if layer_scale_init is not None else nn.Identity()
+        )
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        key_padding_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x:                 (B, N, dim)
+            key_padding_mask:  (B, N) bool — True means *ignore* that position.
+        Returns:
+            (B, N, dim)
+        """
+        # --- Self-attention (pre-norm) ---
+        residual = x
+        x = self.norm1(x)
+        attn_out, _ = self.attn(x, x, x, key_padding_mask=key_padding_mask)
+        x = residual + self.drop_path1(self.ls1(attn_out))
+
+        # --- FFN (pre-norm) ---
+        residual = x
+        x = self.norm2(x)
+        x = residual + self.drop_path2(self.ls2(self.ffn(x)))
+
+        return x
+
+
+class TransformerEncoder(nn.Module):
+    """Stack of TransformerEncoderLayers.
+
+    Args:
+        dim:                  Model dimension.
+        num_layers:           Number of encoder layers.
+        num_heads:            Number of attention heads.
+        activation:           'GELU' or 'SwiGLU'. Default 'SwiGLU'.
+        norm:                 'LayerNorm' or 'RMSNorm'. Default 'LayerNorm'.
+        layer_scale_init:     LayerScale init value (None to disable). Default 1e-4.
+        drop_path_rate:       Maximum drop path (stochastic depth) rate. Linearly
+                              increases from 0 at the first layer to this value at
+                              the last layer. Default 0.0 (disabled).
+        num_registers:        Number of learnable register tokens prepended before
+                              the input tokens (à la DINOv2). Default 0.
+        mlp_ratio:            FFN hidden dim multiplier (ffn_dim = mlp_ratio * dim).
+                              Default 4. For SwiGLU, inner dim is scaled by 2/3 to
+                              keep parameter count comparable.
+        qkv_bias:             Bias in QKV projections. Default True.
+        attention_dropout:    Dropout on attention weights. Default 0.0.
+        norm_eps:             Epsilon for norm layers. Default 1e-5.
+        apply_final_norm:     Apply a norm after the last layer. Default True.
+        apply_embedding_norm: Apply a norm to the input embeddings before the first
+                              layer. Default False.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_layers: int,
+        num_heads: int,
+        activation: Literal["GELU", "SwiGLU"] = "SwiGLU",
+        norm: Literal["LayerNorm", "RMSNorm"] = "LayerNorm",
+        layer_scale_init: float | None = 1e-4,
+        drop_path_rate: float = 0.0,
+        num_registers: int = 0,
+        mlp_ratio: int = 4,
+        qkv_bias: bool = True,
+        attention_dropout: float = 0.0,
+        norm_eps: float = 1e-5,
+        apply_final_norm: bool = True,
+        apply_embedding_norm: bool = False,
+    ):
+        super().__init__()
+
+        # For SwiGLU, scale inner dim by 2/3 so parameter count matches a
+        # standard 4*dim GELU FFN (SwiGLU has 3 matrices vs 2).
+        if activation == "SwiGLU":
+            ffn_dim = int(mlp_ratio * dim * 2 / 3)
+        else:
+            ffn_dim = mlp_ratio * dim
+
+        # Linearly increasing drop path rates from 0 to drop_path_rate
+        dpr = [drop_path_rate * i / max(num_layers - 1, 1) for i in range(num_layers)]
+
+        self.layers = nn.ModuleList(
+            [
+                TransformerEncoderLayer(
+                    dim=dim,
+                    num_heads=num_heads,
+                    ffn_dim=ffn_dim,
+                    activation=activation,
+                    norm=norm,
+                    layer_scale_init=layer_scale_init,
+                    drop_path=dpr[i],
+                    qkv_bias=qkv_bias,
+                    attention_dropout=attention_dropout,
+                    norm_eps=norm_eps,
+                )
+                for i in range(num_layers)
+            ]
+        )
+
+        self.final_norm = get_norm(norm, dim, eps=norm_eps) if apply_final_norm else nn.Identity()
+        self.embedding_norm = (
+            get_norm(norm, dim, eps=norm_eps) if apply_embedding_norm else nn.Identity()
+        )
+
+        # Register tokens: always valid, prepended before input tokens
+        self.num_registers = num_registers
+        if num_registers > 0:
+            self.register_tokens = nn.Parameter(torch.zeros(1, num_registers, dim))
+            nn.init.trunc_normal_(self.register_tokens, std=0.02)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        key_padding_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            x:                (B, N, dim)
+            key_padding_mask: (B, N) bool — True means ignore. Should NOT include
+                              positions for register tokens; those are prepended here.
+        Returns:
+            (B, N, dim) — register positions are stripped, output length matches input.
+        """
+        B = x.size(0)
+        x = self.embedding_norm(x)
+
+        # Prepend register tokens (always valid → False in mask)
+        if self.num_registers > 0:
+            regs = self.register_tokens.expand(B, -1, -1)  # (B, R, dim)
+            x = torch.cat([regs, x], dim=1)  # (B, R+N, dim)
+            if key_padding_mask is not None:
+                reg_mask = torch.zeros(B, self.num_registers, dtype=torch.bool, device=x.device)
+                key_padding_mask = torch.cat([reg_mask, key_padding_mask], dim=1)
+
+        for layer in self.layers:
+            x = layer(x, key_padding_mask=key_padding_mask)
+
+        x = self.final_norm(x)
+
+        # Strip register tokens before returning
+        if self.num_registers > 0:
+            x = x[:, self.num_registers :]
+
+        return x

--- a/src/HH4b/neural_network/prepare_data.py
+++ b/src/HH4b/neural_network/prepare_data.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib
+import json
+import logging
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from HH4b import utils
+from HH4b.hh_vars import mreg_strings, samples_run3, txbb_strings
+from HH4b.postprocessing import HLTs, load_run3_samples
+
+warnings.filterwarnings("ignore")
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(name)-20s %(message)s"
+)
+
+# ── Sample overrides (consistent with TrainBDT.py) ──────────────────────────
+# Keep a deep copy so we don't mutate the module-level dict for other imports
+samples = copy.deepcopy(samples_run3)
+
+# QCD_HT for 2024, QCD-4Jets_HT for 2022/2023
+for _year in samples:
+    samples[_year]["qcd"] = [
+        "QCD_HT-100to200",
+        "QCD_HT-200to400",
+        "QCD_HT-400to600",
+        "QCD_HT-600to800",
+        "QCD_HT-800to1000",
+        "QCD_HT-1000to1200",
+        "QCD_HT-1200to1500",
+        "QCD_HT-1500to2000",
+        "QCD_HT-2000",
+        "QCD-4Jets_HT-100to200",
+        "QCD-4Jets_HT-200to400",
+        "QCD-4Jets_HT-400to600",
+        "QCD-4Jets_HT-600to800",
+        "QCD-4Jets_HT-800to1000",
+        "QCD-4Jets_HT-1000to1200",
+        "QCD-4Jets_HT-1200to1500",
+        "QCD-4Jets_HT-1500to2000",
+        "QCD-4Jets_HT-2000",
+    ]
+    samples[_year]["ttbar"] = [
+        "TTto2L2Nu",
+        "TTto4Q",
+        "TTtoLNu2Q",
+    ]
+    samples[_year]["diboson"] = [
+        "WW",
+        "WZ",
+        "ZZ",
+    ]
+
+# ── Extra columns needed for NN training (not in postprocessing defaults) ───
+NN_EXTRA_COLUMNS = [
+    ("ht", 1),
+    ("nJets", 1),
+    ("nFatJets", 1),
+    ("bbFatJetMass", 2),
+    ("bbFatJetPNetMass", 2),
+    ("bbFatJetPNetMassRaw", 2),
+    ("bbFatJetPNetMassLegacy", 2),
+    ("bbFatJetParT3PTopbWev", 2),
+    ("bbFatJetParT3PTopbWmv", 2),
+    ("bbFatJetParT3PTopbWq", 2),
+    ("bbFatJetParT3PTopbWqq", 2),
+    ("bbFatJetParT3PTopbWtauhv", 2),
+    ("bbFatJetParT3PXbb", 2),
+    ("bbFatJetParT3PXcc", 2),
+    ("bbFatJetParT3PXcs", 2),
+    ("bbFatJetParT3PXqq", 2),
+    ("AK4JetAwayrawFactor", 2),
+    ("AK4JetAwaybtagDeepFlavB", 2),
+    ("AK4JetAwaybtagPNetB", 2),
+    ("AK4JetAwaybtagPNetCvB", 2),
+    ("AK4JetAwaybtagPNetCvL", 2),
+    ("AK4JetAwaybtagPNetQvG", 2),
+    ("VBFJetrawFactor", 2),
+    ("VBFJetbtagDeepFlavB", 2),
+    ("VBFJetbtagPNetB", 2),
+    ("VBFJetbtagPNetCvB", 2),
+    ("VBFJetbtagPNetCvL", 2),
+    ("VBFJetbtagPNetQvG", 2),
+]
+
+# ── Preselection cuts (consistent with TrainBDT.py) ─────────────────────────
+txbb_preselection = {
+    "bbFatJetPNetTXbb": 0.3,
+    "bbFatJetPNetTXbbLegacy": 0.8,
+    "bbFatJetParTTXbb": 0.3,
+    "bbFatJetParT3TXbb": 0.3,
+}
+msd1_preselection = {
+    "bbFatJetPNetTXbb": 40,
+    "bbFatJetPNetTXbbLegacy": 40,
+    "bbFatJetParTTXbb": 40,
+    "bbFatJetParT3TXbb": 40,
+}
+msd2_preselection = {
+    "bbFatJetPNetTXbb": 30,
+    "bbFatJetPNetTXbbLegacy": 0,
+    "bbFatJetParTTXbb": 30,
+    "bbFatJetParT3TXbb": 30,
+}
+
+
+def apply_cuts(events_dict, txbb_str, mass_str):
+    """
+    Apply cuts consistent with TrainBDT.py.
+    pT(1,2) > 250, mReg(1,2) > 50 and TXbb(1) and mSD(1,2) preselection.
+    """
+    for key in list(events_dict.keys()):
+        events = events_dict[key]
+        n_before = len(events)
+        msd1 = events["bbFatJetMsd"][0]
+        msd2 = events["bbFatJetMsd"][1]
+        pt1 = events["bbFatJetPt"][0]
+        pt2 = events["bbFatJetPt"][1]
+        txbb1 = events[txbb_str][0]
+        mass1 = events[mass_str][0]
+        mass2 = events[mass_str][1]
+        events_dict[key] = events[
+            (pt1 > 250)
+            & (pt2 > 250)
+            & (txbb1 > txbb_preselection[txbb_str])
+            & (msd1 > msd1_preselection[txbb_str])
+            & (msd2 > msd2_preselection[txbb_str])
+            & (mass1 > 50)
+            & (mass2 > 50)
+        ].copy()
+        logger.info(f"    {key}: {len(events_dict[key])} / {n_before} events pass cuts")
+    return events_dict
+
+
+def parse_args():
+    storage_dir = Path("/ceph/cms/store/user/zichun/bbbb")
+    default_tag = "nanov15_20251202_v15_signal"
+
+    parser = argparse.ArgumentParser(description="Prepare Neural Network training dataframes.")
+    parser.add_argument("--tag", default=default_tag)
+    parser.add_argument("--years", nargs="+", default=["2024"])
+    parser.add_argument("--txbb", default="glopart-v3")
+    parser.add_argument("--mass", default=None, help="Mass variable (default: from txbb version)")
+    parser.add_argument("--input-dir", default=str(storage_dir / f"skimmer/{default_tag}"))
+    parser.add_argument(
+        "--output-dir", default=str(storage_dir / f"signal_processed/nn_training/{default_tag}")
+    )
+    parser.add_argument("--bdt-config", default="v13_glopartv3")
+    parser.add_argument(
+        "--sig-keys",
+        nargs="+",
+        default=["hh4b", "vbfhh4b-k2v0"],
+        help="Signal sample keys",
+    )
+    parser.add_argument(
+        "--bg-keys",
+        nargs="+",
+        default=["qcd", "ttbar"],
+        help="Background sample keys",
+    )
+    parser.add_argument("--apply-cuts", action="store_true", default=True)
+    parser.add_argument(
+        "--train-frac", type=float, default=0.80, help="Fraction for training set (default: 0.80)"
+    )
+    parser.add_argument(
+        "--val-frac", type=float, default=0.10, help="Fraction for validation set (default: 0.10)"
+    )
+    parser.add_argument(
+        "--test-frac", type=float, default=0.10, help="Fraction for test set (default: 0.10)"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42, help="Random seed for splitting (default: 42)"
+    )
+    return parser.parse_args()
+
+
+def validate_fracs(args):
+    total = args.train_frac + args.val_frac + args.test_frac
+    if not np.isclose(total, 1.0):
+        raise ValueError(
+            f"--train-frac + --val-frac + --test-frac must sum to 1.0, got {total:.4f}"
+        )
+
+
+def cleanup_events(events: pd.DataFrame) -> pd.DataFrame:
+    """Replace NaN values and out-of-range values (|x| > 50000) with -99999."""
+    for col in events.columns:
+        if "weight" not in col[0].lower():
+            events[col] = events[col].apply(lambda x: -99999 if pd.isna(x) or abs(x) > 50000 else x)
+    return events
+
+
+def train_val_test_split(
+    events: pd.DataFrame,
+    train_frac: float,
+    val_frac: float,
+    seed: int,
+) -> dict[str, pd.DataFrame]:
+    """Shuffle and split events into train / val / test DataFrames."""
+    rng = np.random.default_rng(seed)
+    idx = rng.permutation(len(events))
+
+    n_train = int(np.floor(train_frac * len(events)))
+    n_val = int(np.floor(val_frac * len(events)))
+
+    splits = {
+        "train": events.iloc[idx[:n_train]],
+        "val": events.iloc[idx[n_train : n_train + n_val]],
+        "test": events.iloc[idx[n_train + n_val :]],
+    }
+    return splits
+
+
+def main():
+    args = parse_args()
+    validate_fracs(args)
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    txbb_str = txbb_strings[args.txbb]
+    mass_str = args.mass if args.mass else mreg_strings[args.txbb]
+
+    bdt_dataframe_fn = importlib.import_module(
+        f".{args.bdt_config}", package="HH4b.boosted.bdt_trainings_run3"
+    ).bdt_dataframe
+
+    # Determine which sample keys to load
+    training_keys = args.sig_keys + args.bg_keys
+    aux_keys = ["vhtobb", "tthtobb", "diboson", "vjets"]
+    keys_to_load = training_keys + aux_keys
+
+    # Filter samples to only include requested keys
+    samples_to_load = copy.deepcopy(samples)
+    for year in list(samples_to_load.keys()):
+        if year not in args.years:
+            for key in list(samples_to_load[year].keys()):
+                del samples_to_load[year][key]
+        else:
+            for key in list(samples_to_load[year].keys()):
+                if key not in keys_to_load:
+                    del samples_to_load[year][key]
+
+    logger.info(f"Samples to load: {samples_to_load}")
+
+    for year in args.years:
+        logger.info(f"Loading {year} with txbb={args.txbb}")
+
+        # Use load_run3_samples consistent with TrainBDT.py
+        events_dict = load_run3_samples(
+            input_dir,
+            year,
+            samples_to_load,
+            reorder_txbb=True,
+            load_systematics=False,
+            txbb_version=args.txbb,
+            scale_and_smear=False,
+            mass_str=mass_str,
+            bdt_version=args.bdt_config,
+            load_bdt_scores=False,
+            extra_columns=NN_EXTRA_COLUMNS,
+        )
+
+        # Apply cuts consistent with TrainBDT.py
+        if args.apply_cuts:
+            logger.info("Applying kinematic cuts...")
+            events_dict = apply_cuts(events_dict, txbb_str, mass_str)
+
+        # Apply trigger selection (skimmer does not apply trigger for signal region MC)
+        hlt_cols = [hlt for hlt in HLTs[year]]  # noqa: C416
+        n_before_trig = sum(len(events_dict[k]) for k in events_dict)
+        for key in list(events_dict.keys()):
+            trigger_mask = events_dict[key][
+                [col for col in events_dict[key].columns if col[0] in hlt_cols]
+            ].any(axis=1)
+            events_dict[key] = events_dict[key][trigger_mask]
+        n_after_trig = sum(len(events_dict[k]) for k in events_dict)
+        logger.info(f"    Trigger selection: {n_after_trig} / {n_before_trig} events pass")
+
+        # Filter keys to only those that loaded
+        sig_keys = [k for k in args.sig_keys if k in events_dict]
+        bg_keys = [k for k in args.bg_keys if k in events_dict]
+
+        # Log weights and equalization scaling factors
+        weight_totals = {}
+        for key in sig_keys + bg_keys:
+            weight_totals[key] = np.sum(np.abs(events_dict[key]["finalWeight"].to_numpy()))
+            logger.info(
+                f"    {key}: total weight = {weight_totals[key]:.3f}, events = {len(events_dict[key])}"
+            )
+
+        bkg_total = sum(weight_totals[k] for k in bg_keys)
+        sig_total = sum(weight_totals[k] for k in sig_keys)
+        num_sigs = len(sig_keys)
+        logger.info(f"    Total bkg weight: {bkg_total:.3f}")
+        logger.info(f"    Total sig weight: {sig_total:.3f}")
+        # Compute class weights (equalize signal = bkg)
+        class_weights = {}
+        for key in sig_keys:
+            class_weights[key] = (bkg_total / weight_totals[key]) / num_sigs
+        for key in bg_keys:
+            class_weights[key] = 1.0
+
+        logger.info("    Equalize-weights scaling factors (signal = bkg):")
+        for key, scale in class_weights.items():
+            logger.info(f"        {key}: x{scale:.3f}")
+
+        # Save class weights json
+        weights_path = output_dir / f"class_weights_{year}.json"
+        with open(weights_path, "w") as f:  # noqa: PTH123
+            json.dump(class_weights, f, indent=2)
+        logger.info(f"    Class weights saved to {weights_path}")
+
+        # Process each sample
+        for sample, events in events_dict.items():
+            if len(events) == 0:
+                logger.warning(f"    {sample}: no events after cuts, skipping")
+                continue
+
+            logger.info(f"    {sample}: {len(events)} events")
+
+            logger.info(f"    Computing BDT input variables for {sample}...")
+            bdt_df = bdt_dataframe_fn(events, utils.get_var_mapping(""))
+            bdt_df.columns = pd.MultiIndex.from_tuples([(col, 0) for col in bdt_df.columns])
+
+            events = cleanup_events(pd.concat([events, bdt_df], axis=1))  # noqa: PLW2901
+
+            # Split and save
+            splits = train_val_test_split(events, args.train_frac, args.val_frac, args.seed)
+            splits["all"] = events
+            for split_name, split_df in splits.items():
+                save_path = output_dir / f"{split_name}/{year}_{sample}.parquet"
+                save_path.parent.mkdir(exist_ok=True, parents=True)
+                logger.info(f"        [{split_name:5s}] {len(split_df):>7,} events -> {save_path}")
+                split_df.to_parquet(save_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/HH4b/neural_network/train.py
+++ b/src/HH4b/neural_network/train.py
@@ -1,0 +1,1177 @@
+"""
+train.py — Training script for JetClassifier.
+
+Usage:
+    python train.py --config config.yaml [--use-wandb]
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+from datetime import timedelta
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import yaml
+from accelerate import Accelerator, DataLoaderConfiguration
+from accelerate.utils import InitProcessGroupKwargs, send_to_device
+
+# ---------------------------------------------------------------------------
+# Project imports
+# ---------------------------------------------------------------------------
+from models import (
+    InputEmbedding,
+    JetClassifier,
+    TransformerEncoder,
+    build_mlp_head,
+)
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from utils import (
+    LOGGER,
+    GroupConfig,
+    JetDataset,
+    ScoreAccumulator,
+    compute_roc_metrics,
+    compute_roc_per_signal,
+    configure_logger,
+    get_scheduler,
+    jet_collate_fn,
+    load_checkpoint,
+    resolve_output_dir,
+    save_checkpoint,
+    save_roc_per_signal,
+    save_roc_plot,
+)
+
+
+def setup_training_precision(config: dict[str, Any]) -> bool:
+    """Configure matmul precision and bf16. Returns resolved use_bf16."""
+    matmul_precision = config.get("float32_matmul_precision", "highest")
+    torch.set_float32_matmul_precision(matmul_precision)
+    LOGGER.info(f"float32 matmul precision: {matmul_precision}")
+
+    use_bf16 = config.get("use_bf16", False)
+    if use_bf16:
+        if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+            LOGGER.info("bf16 enabled")
+        else:
+            LOGGER.warning(
+                "use_bf16=True but bf16 is not supported on this device — falling back to fp32"
+            )
+            use_bf16 = False
+    return use_bf16
+
+
+class FocalLoss(nn.Module):
+    """Multi-class focal loss: FL(p_t) = -alpha_t * (1 - p_t)^gamma * log(p_t).
+
+    Args:
+        weight:  Per-class weights (same as nn.CrossEntropyLoss `weight`).
+        gamma:   Focusing parameter. 0 = standard cross-entropy.
+        reduction: 'mean' or 'sum'.
+    """
+
+    def __init__(
+        self,
+        weight: torch.Tensor | None = None,
+        gamma: float = 2.0,
+        reduction: str = "mean",
+    ):
+        super().__init__()
+        self.register_buffer("weight", weight)
+        self.gamma = gamma
+        self.reduction = reduction
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        # 1. Get standard log probabilities
+        log_prob = F.log_softmax(logits, dim=-1)
+
+        # 2. Get UNWEIGHTED cross-entropy to properly calculate p_t
+        ce_unweighted = F.nll_loss(log_prob, targets, reduction="none")
+
+        # 3. Extract p_t (true probability of the correct class)
+        pt = torch.exp(-ce_unweighted)
+
+        # 4. Calculate the focal modifier
+        focal_term = (1.0 - pt) ** self.gamma
+
+        # 5. Apply class weights if provided
+        if self.weight is not None:
+            # Gather the specific weight for each target in the batch
+            alpha = self.weight[targets]
+            loss = alpha * focal_term * ce_unweighted
+        else:
+            loss = focal_term * ce_unweighted
+
+        # 6. Apply reduction
+        if self.reduction == "mean":
+            return loss.mean()
+        elif self.reduction == "sum":
+            return loss.sum()
+
+        return loss
+
+
+def build_loss(config: dict[str, Any], device: torch.device) -> nn.Module:
+    classes = config["dataset"]["classes"]
+    weights = torch.tensor([c["cls_weights"] for c in classes], dtype=torch.float32)
+    # weights = weights / weights.mean()  # normalize
+    weights = weights.to(device)
+
+    loss_cfg = config["training"].get("loss", {})
+    loss_type = loss_cfg if isinstance(loss_cfg, str) else loss_cfg.get("type", "CrossEntropy")
+    loss_type = loss_type.lower()
+
+    if "focal" in loss_type:
+        gamma = loss_cfg.get("gamma", 2.0) if isinstance(loss_cfg, dict) else 2.0
+        LOGGER.info(f"Using FocalLoss (gamma={gamma})")
+        return FocalLoss(weight=weights, gamma=gamma, reduction="none")  # always none
+    else:
+        LOGGER.info("Using CrossEntropyLoss")
+        return nn.CrossEntropyLoss(weight=weights, reduction="none")
+
+
+def resolve_file_pattern(config: dict[str, Any], split: str) -> list[Path]:
+    """Expand file_pattern for all years and classes, return matching paths."""
+    dataset_cfg = config["dataset"]
+    base_dir = Path(dataset_cfg["dir"])
+    pattern = dataset_cfg["file_pattern"]
+    years = dataset_cfg.get("years", [""])
+    name = config.get("name", "")
+    classes = [c["name"] for c in dataset_cfg.get("classes", [{"name": ""}])]
+
+    paths = []
+    for year in years:
+        for cls in classes:
+            p = (
+                pattern.replace("${split}", split)
+                .replace("${year}", year)
+                .replace("${name}", name)
+                .replace("${class}", cls)
+            )
+            matched = sorted(base_dir.glob(p))
+            if not matched:
+                LOGGER.warning(f"No files matched pattern: {base_dir / p}")
+            paths.extend(Path(m) for m in matched)
+
+    if not paths:
+        raise FileNotFoundError(
+            f"No files found for split='{split}' under {base_dir} with pattern '{pattern}'"
+        )
+    return paths
+
+
+def load_dataframe(paths: list[Path], config: dict) -> pd.DataFrame:
+    classes = [c["name"] for c in config["dataset"]["classes"]]
+    class_to_idx = {c: i for i, c in enumerate(classes)}
+
+    frames = []
+    for p in paths:
+        df = pd.read_parquet(p)
+        # Infer class from filename stem, e.g. "2024_hh4b.parquet" → "hh4b"
+        cls_name = next(
+            (c for c in sorted(classes, key=len, reverse=True) if c in p.stem),
+            None,
+        )
+        if cls_name is None:
+            raise ValueError(f"Cannot infer class from filename: {p.name}")
+        df["label"] = class_to_idx[cls_name]
+        frames.append(df)
+
+    df = pd.concat(frames, ignore_index=True)
+    counts = df["label"].value_counts().sort_index()
+    idx_to_class = dict(enumerate(classes))
+    count_str = "  ".join(f"{idx_to_class.get(i, i)}={n:,}" for i, n in counts.items())
+    # Warn loudly for any class that ended up with zero rows
+    loaded_classes = set(counts[counts > 0].index.tolist())
+    for cls, idx in class_to_idx.items():
+        if idx not in loaded_classes:
+            LOGGER.warning(
+                f"Class '{cls}' has ZERO rows in this split — check that the file exists!"
+            )
+    LOGGER.info(f"Loaded {len(df):,} rows from {len(paths)} file(s)  [{count_str}]")
+    return df
+
+
+def _pad_dataframe(df: pd.DataFrame, batch_size: int, weight_key: str | None) -> pd.DataFrame:
+    remainder = len(df) % batch_size
+    if remainder == 0:
+        return df
+    n_pad = batch_size - remainder
+    pad = df.iloc[:n_pad].copy()
+    if weight_key is not None:
+        pad[weight_key] = 0.0
+        return pd.concat([df, pad], ignore_index=True)
+    else:
+        # No weight column — just trim instead of padding with unmasked samples
+        n_keep = len(df) - remainder
+        LOGGER.warning(
+            f"No weight_key set; trimming {remainder} samples to avoid partial last batch "
+            f"({len(df):,} → {n_keep:,})"
+        )
+        return df.iloc[:n_keep].reset_index(drop=True)
+
+
+def build_dataloaders(
+    config: dict[str, Any],
+    config_path: str,
+    device: torch.device,
+    is_main: bool = False,
+    accelerator: Accelerator | None = None,
+) -> tuple[DataLoader, DataLoader]:
+    group_configs = JetDataset.build_group_configs(config)
+    batch_size = config["training"]["batch_size"]
+    num_workers = config["training"].get("num_workers", 2)
+    # collate runs in worker subprocesses when num_workers>0; forked workers
+    # can't initialize CUDA, so keep transforms on CPU and let Accelerate /
+    # pin_memory handle the H2D copy.
+    collate_device = device if num_workers == 0 else None
+    collate_fn = partial(jet_collate_fn, group_configs=group_configs, device=collate_device)
+
+    if is_main:
+        train_df = load_dataframe(resolve_file_pattern(config, "train"), config)
+        val_df = load_dataframe(resolve_file_pattern(config, "val"), config)
+        train_df = _pad_dataframe(train_df, batch_size, config["dataset"].get("weight_key"))
+        val_df = _pad_dataframe(val_df, batch_size, config["dataset"].get("weight_key"))
+        train_ds = JetDataset(train_df, config_path=config_path)
+        val_ds = JetDataset(val_df, config_path=config_path)
+
+        train_loader = DataLoader(
+            train_ds,
+            batch_size=batch_size,
+            shuffle=True,
+            drop_last=False,
+            collate_fn=collate_fn,
+            num_workers=num_workers,
+            pin_memory=(device.type == "cuda"),
+            persistent_workers=(num_workers > 0),
+        )
+        val_loader = DataLoader(
+            val_ds,
+            batch_size=batch_size,
+            shuffle=False,
+            drop_last=False,
+            collate_fn=collate_fn,
+            num_workers=num_workers,
+            pin_memory=(device.type == "cuda"),
+            persistent_workers=(num_workers > 0),
+        )
+    else:
+        train_loader = DataLoader([], collate_fn=collate_fn)
+        val_loader = DataLoader([], collate_fn=collate_fn)
+
+    if accelerator is not None:
+        accelerator.wait_for_everyone()
+
+    return train_loader, val_loader
+
+
+def build_split_dataloader(
+    config: dict[str, Any],
+    config_path: str,
+    split: str,
+    device: torch.device,
+) -> DataLoader:
+    """Build a DataLoader for an arbitrary split (train/val/test)."""
+    group_configs = JetDataset.build_group_configs(config)
+    batch_size = config["training"]["batch_size"]
+    num_workers = config["training"].get("num_workers", 2)
+    collate_device = device if num_workers == 0 else None
+    collate_fn = partial(jet_collate_fn, group_configs=group_configs, device=collate_device)
+
+    df = load_dataframe(resolve_file_pattern(config, split), config)
+    df = _pad_dataframe(df, batch_size, config["dataset"].get("weight_key"))
+    ds = JetDataset(df, config_path=config_path)
+    return DataLoader(
+        ds,
+        batch_size=batch_size,
+        shuffle=False,
+        drop_last=False,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+        pin_memory=(device.type == "cuda"),
+        persistent_workers=(num_workers > 0),
+    )
+
+
+def build_model(config: dict[str, Any]) -> JetClassifier:
+    """Build JetClassifier from config + dataset group configs.
+
+    Steps:
+        1. Read encoder dim and group configs to build InputEmbedding per group.
+        2. Build TransformerEncoder from architecture.encoder.
+        3. Build MLP head from architecture.head.
+        4. Wrap in JetClassifier.
+    """
+
+    arch = config["architecture"]
+    enc_cfg = arch["encoder"]
+    head_cfg = arch["head"]
+
+    dim = enc_cfg["dim"]
+    num_classes = len(config["dataset"]["classes"])
+
+    # --- InputEmbeddings ---
+    group_configs: list[GroupConfig] = JetDataset.build_group_configs(config)
+    embeddings = nn.ModuleDict()
+    for grp in group_configs:
+        embeddings[grp.name] = InputEmbedding(
+            n_continuous=grp.n_continuous,
+            dim=dim,
+            discrete_num_bins=grp.discrete_num_bins(),
+        )
+
+    # --- Encoder ---
+    encoder = TransformerEncoder(
+        dim=dim,
+        num_layers=enc_cfg["num_layers"],
+        num_heads=enc_cfg["num_heads"],
+        activation=enc_cfg.get("activation", "SwiGLU"),
+        norm=enc_cfg.get("norm", "LayerNorm"),
+        layer_scale_init=enc_cfg.get("layer_scale_init", 1e-4),
+        drop_path_rate=enc_cfg.get("drop_path_rate", 0.0),
+        num_registers=enc_cfg.get("num_registers", 0),
+        mlp_ratio=enc_cfg.get("mlp_ratio", 4),
+        qkv_bias=enc_cfg.get("qkv_bias", True),
+        attention_dropout=enc_cfg.get("attention_dropout", 0.0),
+        norm_eps=enc_cfg.get("norm_eps", 1e-5),
+        apply_final_norm=enc_cfg.get("apply_final_norm", True),
+        apply_embedding_norm=enc_cfg.get("apply_embedding_norm", False),
+    )
+
+    # --- Head ---
+    # Pool output is CLS ⊕ masked mean → 2 * dim
+    hidden_dim = head_cfg.get("mlp_hidden_dim")
+    if isinstance(hidden_dim, int):
+        hidden_dim = [hidden_dim] * head_cfg.get("num_hidden_layers", 1)
+
+    head = build_mlp_head(
+        in_dim=2 * dim,
+        num_classes=num_classes,
+        hidden_dim=hidden_dim,
+        num_hidden_layers=head_cfg.get("num_hidden_layers", 1),
+        batch_norm=head_cfg.get("batch_norm", False),
+        dropout=head_cfg.get("dropout", 0.0),
+    )
+
+    model = JetClassifier(
+        embeddings=embeddings,
+        encoder=encoder,
+        head=head,
+        dim=dim,
+        use_type_embed=arch.get("use_type_embed", False),
+    )
+
+    n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    LOGGER.info(f"Built model with {n_params:,} trainable parameters")
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+
+def save_ckpt(
+    config: dict[str, Any],
+    epoch: int,
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    scheduler: Any,
+    val_loss: float,
+    is_best: bool,
+    accelerator: Accelerator | None = None,
+) -> None:
+    unwrapped_model = accelerator.unwrap_model(model) if accelerator is not None else model
+    ckpt = {
+        "epoch": epoch,
+        "model": unwrapped_model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "scheduler": scheduler.state_dict() if scheduler is not None else None,
+        "val_loss": val_loss,
+    }
+    path = save_checkpoint(ckpt, config=config, epoch_num=epoch)
+    LOGGER.info(f"Saved checkpoint → {path}")
+    if is_best:
+        best_path = save_checkpoint(ckpt, config=config, epoch_num="best")
+        LOGGER.info(f"New best model → {best_path}")
+
+
+def maybe_resume(
+    config: dict[str, Any],
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    scheduler: Any,
+) -> tuple[int, float]:
+    """Load checkpoint if training.load_epoch is set. Returns (start_epoch, best_val_loss)."""
+    load_epoch = config["training"].get("load_epoch")
+    if load_epoch is None:
+        return 0, float("inf")
+
+    LOGGER.info(f"Resuming from epoch: {load_epoch}")
+    # Will determine device later
+    ckpt = load_checkpoint(config=config, epoch_num=load_epoch, map_location="cpu")
+
+    model.load_state_dict(ckpt["model"])
+    optimizer.load_state_dict(ckpt["optimizer"])
+
+    if scheduler is not None and ckpt.get("scheduler") is not None:
+        scheduler.load_state_dict(ckpt["scheduler"])
+
+    start_epoch = ckpt["epoch"] + 1
+    best_val_loss = ckpt.get("val_loss", float("inf"))
+    LOGGER.info(f"Resumed from epoch {ckpt['epoch']}, best val_loss={best_val_loss:.4f}")
+    return start_epoch, best_val_loss
+
+
+# ---------------------------------------------------------------------------
+# Train / val loops
+# ---------------------------------------------------------------------------
+def run_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer | None,
+    device: torch.device,
+    is_train: bool,
+    use_bf16: bool = False,
+    epoch: int = 0,
+    accelerator: Accelerator | None = None,
+    wandb_run: Any = None,
+    global_step: int = 0,
+    collect_scores: bool = False,
+    max_grad_norm: float | None = None,
+    use_weights_loss: bool = True,
+    use_weights_acc: bool = True,
+    use_weights_roc: bool = True,
+) -> tuple[float, float, int, ScoreAccumulator | None]:
+    model.train() if is_train else model.eval()
+    total_loss, correct, total = 0.0, 0, 0
+    accumulator = ScoreAccumulator() if collect_scores else None
+
+    amp_ctx = (
+        torch.autocast(device_type=device.type, dtype=torch.bfloat16)
+        if (use_bf16 and accelerator is None)
+        else contextlib.nullcontext()
+    )
+    grad_ctx = torch.enable_grad() if is_train else torch.no_grad()
+
+    phase = "train" if is_train else "val"
+    is_main = (accelerator is None) or (accelerator.is_main_process)
+    pbar = tqdm(
+        loader,
+        desc=f"Epoch {epoch:03d} [{phase}]",
+        leave=False,
+        dynamic_ncols=True,
+        disable=not is_main,
+    )
+
+    with grad_ctx:
+        for batch in pbar:
+            # Accelerate-prepared loaders yield on-device batches; raw eval
+            # loaders yield CPU batches (collate runs in workers). send_to_device
+            # is a no-op when tensors are already on `device`.
+            batch = send_to_device(batch, device, non_blocking=True)  # noqa: PLW2901
+            labels = batch.pop("label")
+            sample_weight_raw = batch.pop("sample_weight", None)
+
+            # Resolve per-use weights — fall back to uniform 1s when flag is off
+            # or when no weight_key was provided in the dataset config.
+            def _weights_or_ones(use_flag: bool) -> torch.Tensor | None:
+                if use_flag and sample_weight_raw is not None:  # noqa: B023
+                    return sample_weight_raw  # noqa: B023
+                return None  # caller treats None as uniform weight
+
+            loss_weights = _weights_or_ones(use_weights_loss)
+            acc_weights = _weights_or_ones(use_weights_acc)
+            roc_weights = _weights_or_ones(use_weights_roc)
+
+            with amp_ctx:
+                logits = model(batch)
+                loss_per_sample = criterion(logits, labels)  # (B,)
+
+                if loss_weights is not None:
+                    loss = (loss_per_sample * loss_weights).sum() / loss_weights.sum().clamp(
+                        min=1e-8
+                    )
+                else:
+                    loss = loss_per_sample.mean()
+
+            if is_train:
+                optimizer.zero_grad()
+                if accelerator is not None:
+                    accelerator.backward(loss)
+                else:
+                    loss.backward()
+                if max_grad_norm is not None:
+                    if accelerator is not None:
+                        accelerator.clip_grad_norm_(model.parameters(), max_grad_norm)
+                    else:
+                        nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
+                optimizer.step()
+
+                if wandb_run is not None and is_main:
+                    if acc_weights is not None:
+                        batch_acc = (
+                            ((logits.argmax(dim=-1) == labels) * acc_weights).sum()
+                            / acc_weights.sum()
+                        ).item()
+                    else:
+                        batch_acc = (logits.argmax(dim=-1) == labels).float().mean().item()
+                    wandb_run.log(
+                        {
+                            "batch/loss": loss.item(),
+                            "batch/acc": batch_acc,
+                            "batch/lr": optimizer.param_groups[0]["lr"],
+                            "global_step": global_step,
+                        },
+                        step=global_step,
+                    )
+                global_step += 1
+
+            # Score accumulation passes roc_weights (may be None)
+            if accumulator is not None:
+                accumulator.update(logits, labels, roc_weights)
+
+            # Epoch-level loss/acc tracking uses loss_weights and acc_weights respectively
+            batch_size = labels.size(0)
+            if loss_weights is not None:
+                total_loss += loss.item() * loss_weights.sum().item()
+            else:
+                total_loss += loss.item() * batch_size
+
+            if acc_weights is not None:
+                correct += ((logits.argmax(dim=-1) == labels) * acc_weights).sum().item()
+                total += acc_weights.sum().item()
+            else:
+                correct += (logits.argmax(dim=-1) == labels).sum().item()
+                total += batch_size
+
+            pbar.set_postfix(
+                loss=f"{total_loss / total:.5e}",
+                acc=f"{correct / total:.2%}",
+            )
+
+    avg_loss = total_loss / total
+    avg_acc = correct / total
+
+    if accelerator is not None:
+        t = torch.tensor([avg_loss, avg_acc], device=accelerator.device)
+        gathered = accelerator.gather(t)
+        gathered = gathered.view(-1, 2).mean(dim=0)
+        avg_loss, avg_acc = gathered[0].item(), gathered[1].item()
+        LOGGER.info(
+            f"Epoch {epoch:03d} [{phase}] | "
+            f"avg_loss={avg_loss:.5e} avg_acc={avg_acc:.2%} "
+            f"(gathered across {accelerator.num_processes} processes)"
+        )
+
+    return avg_loss, avg_acc, global_step, accumulator
+
+
+# ---------------------------------------------------------------------------
+# ROC evaluation
+# ---------------------------------------------------------------------------
+
+
+def run_roc_eval(
+    accumulator: ScoreAccumulator,
+    config: dict[str, Any],
+    output_dir: Path,
+    epoch: int,
+    wandb_run: Any = None,
+    global_step: int = 0,
+    split: str = "val",
+    subsample_fraction: float = 1.0,
+) -> dict[str, dict[str, Any]]:
+    """Compute ROC metrics for all configured roc_groups and log/save results.
+
+    Args:
+        accumulator:  Filled ScoreAccumulator from the val loop.
+        config:       Full training config dict.
+        output_dir:   Experiment output directory (plots saved under roc_curves/).
+        epoch:        Current epoch (used for filenames and logging).
+        wandb_run:    Active W&B run or None.
+        global_step:  Current global step for W&B x-axis.
+        split:        Which split was evaluated (filters roc_groups by their 'splits' field).
+
+    Returns:
+        {group_name: result_dict} for all evaluated groups.
+    """
+    roc_groups = config["training"].get("roc_groups", [])
+    if not roc_groups:
+        return {}
+
+    classes = [c["name"] for c in config["dataset"]["classes"]]
+    class_to_idx = {c: i for i, c in enumerate(classes)}
+
+    all_logits, all_labels, all_weights = accumulator.finalize()
+    if subsample_fraction < 1.0 and subsample_fraction > 0.0:
+        n_samples = all_labels.size(0)
+        n_keep = int(n_samples * subsample_fraction)
+        indices = torch.randperm(n_samples)[:n_keep]
+        all_logits = all_logits[indices]
+        all_labels = all_labels[indices]
+        if all_weights is not None:
+            all_weights = all_weights[indices]
+
+        LOGGER.info(
+            f"Subsampled {n_samples:,} → {n_keep:,} for ROC evaluation "
+            f"(fraction={subsample_fraction:.2%})"
+        )
+
+    results: dict[str, dict[str, Any]] = {}
+    wandb_metrics: dict[str, float] = {}
+
+    for roc_group in roc_groups:
+        # Only evaluate groups configured for this split
+        if split not in roc_group.get("splits", ["val"]):
+            continue
+
+        name = roc_group["name"]
+        res = compute_roc_metrics(
+            all_logits=all_logits,
+            all_labels=all_labels,
+            all_weights=all_weights,
+            roc_group=roc_group,
+            class_to_idx=class_to_idx,
+        )
+        results[name] = res
+
+        # --- Log to console ---
+        # sig_effs is a list of (eps_b_target, eps_s_achieved) tuples
+        sig_eff_strs = "  ".join(
+            f"eps_s={eps_s:.4f}@eps_b={eps_b:.0e}" for eps_b, eps_s in res["sig_effs"]
+        )
+        LOGGER.info(f"  ROC [{name}] | AUC={res['auc']:.4f}  {sig_eff_strs}")
+
+        # --- Collect W&B metrics ---
+        wandb_metrics[f"roc/{name}/auc"] = res["auc"]
+        for eps_b, eps_s in res["sig_effs"]:
+            wandb_metrics[f"roc/{name}/sig_eff@bkg{eps_b:.0e}"] = eps_s
+
+    if not results:
+        return results
+
+    # --- Save ROC curve plots (config-driven, all on one figure) ---
+    roc_plot_dir = output_dir / "roc_curves"
+    epoch_str = f"{epoch:04d}" if isinstance(epoch, int) else str(epoch)
+    plot_filename = f"roc_{split}_epoch_{epoch_str}"
+    plot_title = f"ROC Curves -- {split} -- Epoch {epoch_str}"
+    save_roc_plot(results, roc_plot_dir, epoch, title=plot_title, filename=plot_filename)
+    LOGGER.info(f"  ROC plots saved → {roc_plot_dir}/{plot_filename}.[png|pdf]")
+
+    # --- Save per-signal ROC plots (one figure per signal, like TrainBDT.py) ---
+    sig_keys = config["training"].get("sig_keys", [])
+    bg_keys = config["training"].get("bg_keys", [])
+    if not sig_keys or not bg_keys:
+        # Infer from roc_groups if not explicitly set
+        all_sig = set()
+        all_bg = set()
+        for rg in roc_groups:
+            all_sig.update(rg.get("signal", []))
+            all_bg.update(rg.get("background", []))
+        sig_keys = sorted(all_sig)
+        bg_keys = sorted(all_bg)
+    if sig_keys and bg_keys:
+        per_sig_results = compute_roc_per_signal(
+            all_logits,
+            all_labels,
+            all_weights,
+            sig_keys=sig_keys,
+            bg_keys=bg_keys,
+            class_to_idx=class_to_idx,
+            bkg_effs=roc_groups[0].get("bkg_effs", [1e-1, 1e-2, 1e-3, 1e-4]),
+        )
+        save_roc_per_signal(per_sig_results, roc_plot_dir, epoch, split=split)
+
+    # --- Log to W&B ---
+    if wandb_run is not None and wandb_metrics:
+        wandb_metrics["epoch"] = epoch
+        wandb_run.log(wandb_metrics, step=global_step)
+
+        # Also log the ROC plot image
+        try:
+            import wandb  # noqa: PLC0415
+
+            fig_path = roc_plot_dir / f"roc_epoch_{epoch:04d}.png"
+            if fig_path.exists():
+                wandb_run.log(
+                    {"roc/curves": wandb.Image(str(fig_path), caption=f"Epoch {epoch:04d}")},
+                    step=global_step,
+                )
+        except Exception:
+            pass
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_splits(
+    model: nn.Module,
+    config: dict[str, Any],
+    config_path: str,
+    device: torch.device,
+    output_dir: Path,
+    epoch: int | str,
+    criterion: nn.Module,
+    use_bf16: bool = False,
+    splits: list[str] | None = None,
+    use_weights_loss: bool = True,
+    use_weights_acc: bool = True,
+    use_weights_roc: bool = True,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Run inference on train/val/test splits and produce ROC curves + metrics JSON.
+
+    Returns:
+        {split_name: {roc_group_name: result_dict}}
+    """
+    if splits is None:
+        splits = ["train", "val", "test"]
+
+    classes = [c["name"] for c in config["dataset"]["classes"]]
+    idx_to_class = {i: c for i, c in enumerate(classes)}  # noqa: C416
+
+    all_results: dict[str, dict[str, dict[str, Any]]] = {}
+
+    for split in splits:
+        LOGGER.info(f"Evaluating split: {split}")
+        try:
+            loader = build_split_dataloader(config, config_path, split, device)
+        except FileNotFoundError:
+            LOGGER.warning(f"No data found for split '{split}' — skipping.")
+            continue
+
+        _, _, _, accumulator = run_epoch(
+            model=model,
+            loader=loader,
+            criterion=criterion,
+            optimizer=None,
+            device=device,
+            is_train=False,
+            use_bf16=use_bf16,
+            epoch=0,
+            collect_scores=True,
+            use_weights_loss=use_weights_loss,
+            use_weights_acc=use_weights_acc,
+            use_weights_roc=use_weights_roc,
+        )
+
+        if accumulator is None:
+            continue
+
+        # --- Save per-sample-key scores and weights ---
+        all_logits, all_labels, all_weights = accumulator.finalize()
+        probs = torch.softmax(all_logits, dim=-1).cpu().numpy()  # (N, num_classes)
+        labels_np = all_labels.cpu().numpy()
+        weights_np = all_weights.cpu().numpy() if all_weights is not None else None
+
+        scores_dir = output_dir / "scores" / f"epoch_{epoch}" / split
+        scores_dir.mkdir(parents=True, exist_ok=True)
+
+        for cls_idx, cls_name in idx_to_class.items():
+            mask = labels_np == cls_idx
+            if not mask.any():
+                continue
+            sample_data = {"scores": probs[mask]}  # (n_samples, num_classes)
+            if weights_np is not None:
+                sample_data["weights"] = weights_np[mask]
+            np.savez(scores_dir / f"{cls_name}.npz", **sample_data)
+            n = int(mask.sum())
+            LOGGER.info(f"  Saved {n:,} scores for {cls_name} → {scores_dir / f'{cls_name}.npz'}")
+
+        # --- ROC evaluation ---
+        results = run_roc_eval(
+            accumulator=accumulator,
+            config=config,
+            output_dir=output_dir,
+            epoch=epoch,
+            split=split,
+        )
+        all_results[split] = results
+
+    # Save combined metrics to JSON
+    metrics_path = output_dir / "roc_curves" / f"eval_metrics_epoch_{epoch}.json"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert to JSON-serializable format
+    json_metrics: dict[str, Any] = {}
+    for split, groups in all_results.items():
+        json_metrics[split] = {}
+        for group_name, res in groups.items():
+            json_metrics[split][group_name] = {
+                "auc": res["auc"],
+                "sig_effs": {f"{eps_b:.0e}": eps_s for eps_b, eps_s in res["sig_effs"]},
+            }
+
+    with metrics_path.open("w") as f:
+        json.dump(json_metrics, f, indent=2)
+    LOGGER.info(f"Evaluation metrics saved → {metrics_path}")
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train JetClassifier")
+    parser.add_argument("--config", "-c", type=str, required=True, help="Path to config YAML")
+    parser.add_argument("--use-wandb", action="store_true", help="Enable Weights & Biases logging")
+    parser.add_argument(
+        "--evaluation-only",
+        action="store_true",
+        help="Skip training; load checkpoint, run inference on train/val/test, and plot ROC curves.",
+    )
+    parser.add_argument(
+        "--eval-epoch",
+        type=str,
+        default="best",
+        help="Checkpoint epoch to load for evaluation (default: 'best'). Use an int or 'best'.",
+    )
+    parser.add_argument("--log-level", type=str, default="DEBUG")
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Path to log file. Overrides the default <output_dir>/logs/train.log",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # --- Config ---
+    with Path(args.config).open() as f:
+        config = yaml.safe_load(f)
+
+    # after device is resolved, before building data/model:
+    use_bf16 = setup_training_precision(config)
+
+    # optionally wrap with accelerate:
+    device = torch.device(config.get("device", "cuda" if torch.cuda.is_available() else "cpu"))
+    accelerator = None
+    use_accelerate = config.get("use_accelerate", False)
+    if use_accelerate:
+        dataloader_config = DataLoaderConfiguration(
+            dispatch_batches=True,  # Main process loads batches
+            split_batches=False,
+        )
+        kwargs = InitProcessGroupKwargs(timeout=timedelta(days=365))
+        accelerator = Accelerator(
+            dataloader_config=dataloader_config,
+            kwargs_handlers=[kwargs],
+            mixed_precision="bf16" if use_bf16 else "no",
+        )
+        device = accelerator.device
+        # only log main process info
+        LOGGER.addFilter(lambda _: accelerator.is_main_process)
+        LOGGER.info(
+            f"Accelerate enabled (device={device}, mixed_precision={accelerator.mixed_precision})"
+        )
+
+    is_main = (accelerator is None) or accelerator.is_main_process
+
+    # --- Output dir & logging ---
+    output_dir = resolve_output_dir(config)
+    if is_main:
+        if args.log_file is not None:
+            log_file = Path(args.log_file)
+        else:
+            log_file = output_dir / "logs" / "train.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        configure_logger(LOGGER, log_file=str(log_file), log_level=args.log_level)
+
+    # --- W&B ---
+    wandb_run = None
+    if args.use_wandb and is_main and not args.evaluation_only:
+        try:
+            import wandb  # noqa: PLC0415
+
+            wandb_run = wandb.init(
+                project="HH4b-nn-trainings",
+                name=config.get("name", "jet-classifier"),
+                config=config,
+                dir=str(output_dir),
+            )
+            LOGGER.info("W&B run initialized")
+        except ImportError:
+            LOGGER.warning("wandb not installed — skipping W&B logging")
+
+    # --- Model ---
+    LOGGER.info("Building model...")
+    model = build_model(config)
+    if accelerator is None:
+        model = model.to(device)
+
+    # --- torch.compile ---
+    if config.get("compile", False):
+        LOGGER.info("Compiling model with torch.compile...")
+        model = torch.compile(model)
+
+    # --- Loss ---
+    criterion = build_loss(config, device)
+
+    # --- Weight flags ---
+    training_cfg = config["training"]
+    use_weights_cfg = training_cfg.get("use_weights", {})
+    if isinstance(use_weights_cfg, bool):
+        use_weights_cfg = {"loss": use_weights_cfg, "acc": use_weights_cfg, "roc": use_weights_cfg}
+    uw_loss = use_weights_cfg.get("loss", True)
+    uw_acc = use_weights_cfg.get("acc", True)
+    uw_roc = use_weights_cfg.get("roc", True)
+
+    # ===================================================================
+    # Evaluation-only mode
+    # ===================================================================
+    if args.evaluation_only:
+        eval_epoch = args.eval_epoch
+        # Try to parse as int; otherwise keep as string (e.g. "best")
+        try:  # noqa: SIM105
+            eval_epoch = int(eval_epoch)
+        except ValueError:
+            pass
+
+        LOGGER.info(f"Evaluation-only mode — loading checkpoint epoch={eval_epoch}")
+        ckpt = load_checkpoint(config=config, epoch_num=eval_epoch, map_location="cpu")
+        model.load_state_dict(ckpt["model"])
+        model.eval()
+
+        evaluate_splits(
+            model=model,
+            config=config,
+            config_path=args.config,
+            device=device,
+            output_dir=output_dir,
+            epoch=eval_epoch,
+            criterion=criterion,
+            use_bf16=use_bf16,
+            use_weights_loss=uw_loss,
+            use_weights_acc=uw_acc,
+            use_weights_roc=uw_roc,
+        )
+        LOGGER.info("Evaluation complete.")
+        return
+
+    # ===================================================================
+    # Training mode
+    # ===================================================================
+
+    # --- Data ---
+    LOGGER.info("Building dataloaders...")
+    train_loader, val_loader = build_dataloaders(
+        config, config_path=args.config, device=device, is_main=is_main, accelerator=accelerator
+    )
+
+    # --- Optimizer ---
+    opt_cfg = training_cfg["optimizer"]
+    optimizer = getattr(torch.optim, opt_cfg["type"])(
+        model.parameters(), **opt_cfg.get("kwargs", {})
+    )
+
+    # --- Scheduler ---
+    scheduler = get_scheduler(optimizer, config)
+
+    # --- Resume ---
+    start_epoch, best_val_loss = maybe_resume(
+        config=config, model=model, optimizer=optimizer, scheduler=scheduler
+    )
+
+    if accelerator is not None:
+        model, optimizer, train_loader, val_loader = accelerator.prepare(
+            model, optimizer, train_loader, val_loader
+        )
+        if scheduler is not None:
+            scheduler = accelerator.prepare(scheduler)
+
+    # --- ROC config ---
+    roc_groups = training_cfg.get("roc_groups", [])
+    has_roc = bool(roc_groups)
+    if has_roc:
+        LOGGER.info(f"ROC evaluation enabled for {len(roc_groups)} group(s)")
+
+    max_grad_norm = training_cfg.get("max_grad_norm", None)
+
+    LOGGER.info(f"use_weights — loss={uw_loss}  acc={uw_acc}  roc={uw_roc}")
+    if max_grad_norm is not None:
+        LOGGER.info(f"Gradient clipping enabled: max_grad_norm={max_grad_norm}")
+
+    num_epochs = training_cfg["num_epochs"]
+    patience = training_cfg.get("patience", float("inf"))
+    epochs_no_improve = 0
+    global_step = 0  # tracks total batches seen across all epochs
+
+    LOGGER.info(f"Starting training from epoch {start_epoch}/{num_epochs}")
+
+    for epoch in range(start_epoch, num_epochs):
+        train_loss, train_acc, global_step, _ = run_epoch(
+            model=model,
+            loader=train_loader,
+            criterion=criterion,
+            optimizer=optimizer,
+            device=device,
+            is_train=True,
+            use_bf16=use_bf16,
+            epoch=epoch,
+            accelerator=accelerator,
+            wandb_run=wandb_run,
+            global_step=global_step,
+            collect_scores=False,
+            max_grad_norm=max_grad_norm,
+            use_weights_loss=uw_loss,
+            use_weights_acc=uw_acc,
+            use_weights_roc=uw_roc,
+        )
+        # First pass without score collection to determine val_loss
+        val_loss, val_acc, _, _ = run_epoch(
+            model=model,
+            loader=val_loader,
+            criterion=criterion,
+            optimizer=None,
+            device=device,
+            is_train=False,
+            use_bf16=use_bf16,
+            epoch=epoch,
+            accelerator=accelerator,
+            wandb_run=None,
+            global_step=global_step,
+            collect_scores=False,
+            use_weights_loss=uw_loss,
+            use_weights_acc=uw_acc,
+            use_weights_roc=uw_roc,
+        )
+
+        if scheduler is not None:
+            scheduler.step()
+
+        is_best = val_loss < best_val_loss
+        if is_best:
+            best_val_loss = val_loss
+            epochs_no_improve = 0
+        else:
+            epochs_no_improve += 1
+
+        # Collect scores only on new best epochs (avoids overhead on non-improving epochs)
+        val_accumulator = None
+        if has_roc and is_best:
+            _, _, _, val_accumulator = run_epoch(
+                model=model,
+                loader=val_loader,
+                criterion=criterion,
+                optimizer=None,
+                device=device,
+                is_train=False,
+                use_bf16=use_bf16,
+                epoch=epoch,
+                accelerator=accelerator,
+                wandb_run=None,
+                global_step=global_step,
+                collect_scores=True,
+                use_weights_loss=uw_loss,
+                use_weights_acc=uw_acc,
+                use_weights_roc=uw_roc,
+            )
+            if val_accumulator is not None and accelerator is not None:
+                val_accumulator = val_accumulator.gather(accelerator)
+
+        if is_main:
+            LOGGER.info(
+                f"Epoch {epoch:04d} | "
+                f"train_loss={train_loss:.5e} train_acc={train_acc:.2%} | "
+                f"val_loss={val_loss:.5e} val_acc={val_acc:.2%}"
+                + (" ← best" if is_best else f" (no improve {epochs_no_improve}/{patience})")
+            )
+
+            save_ckpt(
+                config=config,
+                epoch=epoch,
+                model=model,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                val_loss=val_loss,
+                is_best=is_best,
+                accelerator=accelerator,
+            )
+
+            # --- ROC evaluation (best epochs only) ---
+            if val_accumulator is not None:
+                LOGGER.info(f"Running ROC evaluation for new best epoch {epoch:04d}...")
+                run_roc_eval(
+                    accumulator=val_accumulator,
+                    config=config,
+                    output_dir=output_dir,
+                    epoch=epoch,
+                    wandb_run=wandb_run,
+                    global_step=global_step,
+                    split="val",
+                )
+
+            if wandb_run is not None:
+                wandb_run.log(
+                    {
+                        "epoch": epoch,
+                        "train/loss": train_loss,
+                        "train/acc": train_acc,
+                        "val/loss": val_loss,
+                        "val/acc": val_acc,
+                        "lr": optimizer.param_groups[0]["lr"],
+                    },
+                    step=global_step,
+                )
+
+        should_stop = epochs_no_improve >= patience
+        if accelerator is not None:
+            stop_tensor = torch.tensor(int(should_stop), device=device)
+            torch.distributed.broadcast(stop_tensor, src=0)
+            should_stop = bool(stop_tensor.item())
+
+        if should_stop:
+            if is_main:
+                LOGGER.info(
+                    f"Early stopping triggered after {patience} epochs without improvement."
+                )
+            break
+
+    # --- End-of-training evaluation on all splits ---
+    if is_main and has_roc:
+        LOGGER.info("Running final evaluation on train/val/test splits...")
+        # Unwrap model for evaluation if using accelerate
+        eval_model = accelerator.unwrap_model(model) if accelerator is not None else model
+        evaluate_splits(
+            model=eval_model,
+            config=config,
+            config_path=args.config,
+            device=device,
+            output_dir=output_dir,
+            epoch="final",
+            criterion=criterion,
+            use_bf16=use_bf16,
+            use_weights_loss=uw_loss,
+            use_weights_acc=uw_acc,
+            use_weights_roc=uw_roc,
+        )
+
+    if is_main:
+        LOGGER.info(f"Training complete. Best val_loss={best_val_loss:.4f}")
+        if wandb_run is not None:
+            wandb_run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/HH4b/neural_network/utils/__init__.py
+++ b/src/HH4b/neural_network/utils/__init__.py
@@ -1,0 +1,22 @@
+# ruff: noqa: F401
+
+from __future__ import annotations
+
+from .ckpt import (
+    get_checkpoints_path,
+    load_checkpoint,
+    process_placeholder,
+    resolve_output_dir,
+    save_checkpoint,
+)
+from .dataset import GroupConfig, JetDataset, jet_collate_fn
+from .feature_transform import FeatureTransform
+from .logger import LOGGER, configure_logger
+from .roc import (
+    ScoreAccumulator,
+    compute_roc_metrics,
+    compute_roc_per_signal,
+    save_roc_per_signal,
+    save_roc_plot,
+)
+from .scheduler import get_scheduler

--- a/src/HH4b/neural_network/utils/ckpt.py
+++ b/src/HH4b/neural_network/utils/ckpt.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+PROJECT_ROOT: Path = Path(__file__).resolve().parent.parent
+
+
+def process_placeholder(s: str, config: dict[str, Any], epoch_num: str | int | None) -> str:
+    """
+    Replace placeholders in a string with values from the config.
+    - ${name} or $JOB_NAME: The name of the job, specified by "name" in the config.
+    - $EPOCH_NUM:           The epoch number, given by the epoch_num argument.
+    - $PROJECT_ROOT:        The root directory of the project.
+    """
+    job_name = config.get("name", "") or ""
+    if epoch_num is not None:
+        s = s.replace("${epoch_num}", str(epoch_num))
+    # Support both ${name}
+    s = s.replace("${name}", job_name)
+    s = s.replace("${project_root}", str(PROJECT_ROOT))
+    return s
+
+
+def resolve_output_dir(config: dict[str, Any]) -> Path:
+    """Resolve the output_dir from the config, expanding ${name} placeholders."""
+    raw = config.get("output_dir", "outputs/${name}")
+    return Path(process_placeholder(raw, config=config, epoch_num=None))
+
+
+def get_checkpoints_path(config: dict[str, Any], epoch_num: str | int) -> Path:
+    """
+    Get the path to the checkpoints file based on the training config and epoch number.
+
+    Args:
+        config:    The training config.
+        epoch_num: The epoch number, or 'best'.
+
+    Returns:
+        The path to the checkpoints file.
+    """
+    training_params = config["training"]
+    checkpoints_filename = training_params.get(
+        "checkpoints_filename", "checkpoint_epoch_${epoch_num}.pt"
+    )
+    checkpoints_filename = process_placeholder(
+        s=checkpoints_filename, config=config, epoch_num=epoch_num
+    )
+
+    checkpoints_dir = training_params.get(
+        "checkpoints_dir", str(resolve_output_dir(config) / "checkpoints")
+    )
+    checkpoints_dir = process_placeholder(s=checkpoints_dir, config=config, epoch_num=epoch_num)
+
+    return Path(checkpoints_dir) / checkpoints_filename
+
+
+def get_best_checkpoint_path(config: dict[str, Any]) -> Path:
+    """Return the path for the best checkpoint (epoch_num='best')."""
+    return get_checkpoints_path(config=config, epoch_num="best")
+
+
+def save_checkpoint(
+    checkpoint_dict: dict[str, Any],
+    config: dict[str, Any],
+    epoch_num: int | str,
+) -> Path:
+    """
+    Save the checkpoint to the specified path.
+
+    Args:
+        checkpoint_dict: The checkpoint dictionary to save.
+        config:          The training config.
+        epoch_num:       The epoch number, or 'best'.
+
+    Returns:
+        The path to which the checkpoint was saved.
+    """
+    path = get_checkpoints_path(config=config, epoch_num=epoch_num)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(checkpoint_dict, path)
+    return path
+
+
+def load_checkpoint(
+    config: dict[str, Any],
+    epoch_num: int | str,
+    map_location: str | torch.device = "cpu",
+) -> dict[str, Any]:
+    """
+    Load a checkpoint from disk.
+
+    Args:
+        config:       The training config.
+        epoch_num:    The epoch number, or 'best'.
+        map_location: torch map_location for torch.load.
+
+    Returns:
+        The checkpoint dictionary.
+    """
+    path = get_checkpoints_path(config=config, epoch_num=epoch_num)
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {path}")
+    return torch.load(path, map_location=map_location)

--- a/src/HH4b/neural_network/utils/dataset.py
+++ b/src/HH4b/neural_network/utils/dataset.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+import yaml
+from torch.utils.data import Dataset
+
+from .feature_transform import FeatureTransform
+
+
+def _apply_transform(x: torch.Tensor, transform_cfg: Any) -> torch.Tensor:
+    """Apply a single transform config block to a tensor."""
+    if transform_cfg is None:
+        return x
+
+    if isinstance(transform_cfg, str):
+        t_type = transform_cfg
+        kwargs = {}
+    else:
+        t_type = transform_cfg.get("type")
+        kwargs = transform_cfg.get("kwargs", {}) or {}
+
+    fn = getattr(FeatureTransform, t_type)
+    return fn(x, **kwargs)
+
+
+class GroupConfig:
+    """Pre-parsed configuration for one input group."""
+
+    def __init__(self, cfg: dict):
+        self.name: str = cfg["name"]
+        self.idx: list[int] = cfg["idx"]
+
+        self.masks: list[dict] = cfg.get("mask") or []
+        self.continuous: list[dict] = cfg.get("continuous_features") or []
+        self.discrete: list[dict] = cfg.get("discrete_features") or []
+
+    @property
+    def n_continuous(self) -> int:
+        return len(self.continuous)
+
+    def discrete_num_bins(self) -> list[int]:
+        result = []
+        for feat in self.discrete:
+            bins = feat["transform"]["kwargs"]["bins"]
+            result.append(len(bins) + 1)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Collate — runs in the DataLoader worker (or main process if num_workers=0)
+# ---------------------------------------------------------------------------
+
+
+def jet_collate_fn(
+    batch: list[dict[str, Any]],
+    group_configs: list[GroupConfig],
+    device: torch.device | None = None,
+) -> dict[str, Any]:
+    """Stack per-sample raw tensors into (B, N, D) batches and apply all
+    feature transforms in one vectorised pass.
+
+    PyTorch's DataLoader runs ``collate_fn`` inside each worker subprocess
+    when ``num_workers > 0``.  Forked workers cannot initialise CUDA, so
+    pass ``device=None`` (or a CPU device) when ``num_workers > 0`` and rely
+    on ``pin_memory`` + downstream ``.to(device)`` (or ``accelerator.prepare``)
+    for the H2D copy.  Only pass a CUDA device when ``num_workers == 0``.
+
+    Use via ``functools.partial``::
+
+        from functools import partial
+        collate_fn = partial(jet_collate_fn, group_configs=ds.group_configs(), device=None)
+        DataLoader(ds, ..., collate_fn=collate_fn, num_workers=2, pin_memory=True)
+
+    Args:
+        batch:         List of per-sample dicts from ``JetDataset.__getitem__``.
+        group_configs: Group configs from ``JetDataset.group_configs()``.
+        device:        Target device for the returned tensors.  ``None`` keeps
+                       tensors on CPU (rely on ``pin_memory`` for fast H2D).
+                       Must be ``None`` / CPU when used with ``num_workers > 0``.
+    """
+    result: dict[str, Any] = {}
+
+    # --- Labels & sample weights (already long / float scalars) ---
+    result["label"] = torch.stack([b["label"] for b in batch])  # (B,)
+    if "sample_weight" in batch[0]:
+        result["sample_weight"] = torch.stack([b["sample_weight"] for b in batch])  # (B,)
+
+    # --- Groups ---
+    for grp in group_configs:
+        continuous_raw = torch.stack([b[grp.name]["continuous"] for b in batch])  # (B, N, D_cont)
+        discrete_raw = torch.stack([b[grp.name]["discrete"] for b in batch])  # (B, N, D_disc)
+        mask = torch.stack([b[grp.name]["mask"] for b in batch])  # (B, N)
+
+        if device is not None:
+            continuous_raw = continuous_raw.to(device, non_blocking=True)
+            discrete_raw = discrete_raw.to(device, non_blocking=True)
+            mask = mask.to(device, non_blocking=True)
+
+        with torch.no_grad():
+            # Continuous: transform each feature slice (B, N) independently
+            cont_out: list[torch.Tensor] = []
+            for f_idx, feat in enumerate(grp.continuous):
+                col = continuous_raw[..., f_idx]  # (B, N)
+                t_cfg = feat.get("transform")
+                if isinstance(t_cfg, str):
+                    kwargs = feat.get("kwargs", {}) or {}
+                    col = getattr(FeatureTransform, t_cfg)(col, **kwargs)
+                elif t_cfg is not None:
+                    col = _apply_transform(col, t_cfg)
+                cont_out.append(col)
+
+            if cont_out:
+                continuous = torch.stack(cont_out, dim=-1)  # (B, N, D_cont)
+            else:
+                B, N = continuous_raw.shape[:2]
+                continuous = torch.zeros(B, N, 0, dtype=torch.float32, device=continuous_raw.device)
+
+            # Discrete: transform then cast to long
+            disc_out: list[torch.Tensor] = []
+            for f_idx, feat in enumerate(grp.discrete):
+                col = discrete_raw[..., f_idx]  # (B, N) float32
+                t_cfg = feat.get("transform")
+                col = _apply_transform(col, t_cfg).long()  # (B, N)
+                disc_out.append(col)
+
+            if disc_out:
+                discrete = torch.stack(disc_out, dim=-1)  # (B, N, D_disc)
+            else:
+                B, N = discrete_raw.shape[:2]
+                discrete = torch.zeros(B, N, 0, dtype=torch.long, device=discrete_raw.device)
+
+        result[grp.name] = {
+            "continuous": continuous,  # (B, N, D_cont) float32, transformed
+            "discrete": discrete,  # (B, N, D_disc) long, bin indices
+            "mask": mask,  # (B, N) bool
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+class JetDataset(Dataset):
+    """PyTorch Dataset for jet classification backed by numpy arrays.
+
+    The DataFrame is immediately decomposed into per-column numpy arrays at
+    construction time.  After the DataLoader forks worker processes the arrays
+    are shared via OS copy-on-write rather than being deep-copied, eliminating
+    the x(num_workers+1) memory blow-up that arises when workers hold
+    references to a live pandas DataFrame.
+
+    ``__getitem__`` returns *raw* (un-transformed) tensors.  All feature
+    transforms are applied in ``jet_collate_fn`` on the full batch in the main
+    process, enabling vectorised ops and optional GPU execution.
+
+    Each ``__getitem__`` returns::
+
+        {
+            group_name: {
+                "continuous": Tensor(N, D_cont),   # raw float32
+                "discrete":   Tensor(N, D_disc),   # raw float32 (long after collate)
+                "mask":       Tensor(N,),           # bool, True = invalid
+            },
+            ...
+            "label":         LongTensor scalar,
+            "sample_weight": FloatTensor scalar,   # only if weight_key is set
+        }
+
+    Typical usage::
+
+        ds = JetDataset(df, config_path="config.yaml")
+        collate_fn = partial(jet_collate_fn, group_configs=ds.group_configs(), device=device)
+        loader = DataLoader(ds, batch_size=512, num_workers=4,
+                            pin_memory=True, collate_fn=collate_fn)
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame | None = None,
+        config_path: str | None = None,
+        label_col: str | None = "label",
+    ):
+        super().__init__()
+        self._len = 0
+
+        if config_path is not None:
+            with Path(config_path).open() as f:
+                self.cfg = yaml.safe_load(f)
+            self.groups: list[GroupConfig] = self.build_group_configs(self.cfg)
+            self.classes = [c["name"] for c in self.cfg["dataset"]["classes"]]
+            self.class_to_idx = {c: i for i, c in enumerate(self.classes)}
+            self.weight_key = self.cfg["dataset"].get("weight_key")
+            self.label_col = label_col
+
+        if df is None:
+            return  # non-main rank: valid _len=0, groups set, no data
+
+        # --- data loading (main process only) ---
+        df = df.reset_index(drop=True)
+        self._len = len(df)
+        needed_cols = self._collect_needed_columns()
+        self._cols = {}
+        for col in needed_cols:
+            if col not in df.columns:
+                raise KeyError(f"Column {col} not found. " f"Available: {list(df.columns[:10])}...")
+            self._cols[col] = df[col].to_numpy(dtype=np.float32, na_value=np.nan)
+
+        if label_col is not None:
+            self._labels: np.ndarray | None = df[label_col].to_numpy(dtype=np.int64)
+        else:
+            self._labels = None
+
+        if self.weight_key is not None:
+            self._weights: np.ndarray | None = df[self.weight_key].to_numpy(dtype=np.float32)
+        else:
+            self._weights = None
+
+        # --- Pre-build contiguous arrays per group for fast batch slicing ---
+        self._group_arrays: dict[str, dict[str, np.ndarray]] = {}
+        for grp in self.groups:
+            N = len(grp.idx)
+            L = self._len
+
+            # Continuous: (L, N, D_cont)
+            if grp.continuous:
+                cont = np.stack(
+                    [
+                        np.stack(
+                            [self._cols[(feat["name"], str(idx))] for feat in grp.continuous],
+                            axis=-1,
+                        )
+                        for idx in grp.idx
+                    ],
+                    axis=1,
+                )  # (L, N, D_cont)
+            else:
+                cont = np.zeros((L, N, 0), dtype=np.float32)
+
+            # Discrete: (L, N, D_disc)
+            if grp.discrete:
+                disc = np.stack(
+                    [
+                        np.stack(
+                            [self._cols[(feat["name"], str(idx))] for feat in grp.discrete],
+                            axis=-1,
+                        )
+                        for idx in grp.idx
+                    ],
+                    axis=1,
+                )  # (L, N, D_disc)
+            else:
+                disc = np.zeros((L, N, 0), dtype=np.float32)
+
+            # Mask: (L, N) — True = invalid
+            mask = np.zeros((L, N), dtype=np.bool_)
+            for m_cfg in grp.masks:
+                lo = m_cfg.get("min", float("-inf"))
+                hi = m_cfg.get("max", float("inf"))
+                lo = float(lo) if lo != "inf" else float("inf")
+                hi = float(hi) if hi != "-inf" else float("-inf")
+                for n, idx in enumerate(grp.idx):
+                    vals = self._cols[(m_cfg["name"], str(idx))]
+                    mask[:, n] |= ~((vals > lo) & (vals < hi))
+
+            self._group_arrays[grp.name] = {
+                "continuous": cont,
+                "discrete": disc,
+                "mask": mask,
+            }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _collect_needed_columns(self) -> list[tuple[str, str]]:
+        """Return all (feature, str_idx) keys referenced by any group."""
+        seen: set[tuple[str, str]] = set()
+        out: list[tuple[str, str]] = []
+        for grp in self.groups:
+            for idx in grp.idx:
+                sidx = str(idx)
+                for feat in grp.continuous:
+                    k = (feat["name"], sidx)
+                    if k not in seen:
+                        seen.add(k)
+                        out.append(k)
+                for feat in grp.discrete:
+                    k = (feat["name"], sidx)
+                    if k not in seen:
+                        seen.add(k)
+                        out.append(k)
+                for m in grp.masks:
+                    k = (m["name"], sidx)
+                    if k not in seen:
+                        seen.add(k)
+                        out.append(k)
+        return out
+
+    # ------------------------------------------------------------------
+    # Dataset protocol
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return getattr(self, "_len", 0)
+
+    def __getitem__(self, i: int) -> dict[str, Any]:
+        sample: dict[str, Any] = {}
+
+        for grp in self.groups:
+            arrs = self._group_arrays[grp.name]
+            sample[grp.name] = {
+                "continuous": torch.from_numpy(arrs["continuous"][i]),  # (N, D_cont)
+                "discrete": torch.from_numpy(arrs["discrete"][i]),  # (N, D_disc)
+                "mask": torch.from_numpy(arrs["mask"][i]),  # (N,)
+            }
+
+        if self._labels is not None:
+            sample["label"] = torch.tensor(int(self._labels[i]), dtype=torch.long)
+
+        if self._weights is not None:
+            sample["sample_weight"] = torch.tensor(float(self._weights[i]), dtype=torch.float32)
+
+        return sample
+
+    # ------------------------------------------------------------------
+    # Helpers for model / dataloader building
+    # ------------------------------------------------------------------
+
+    def group_configs(self) -> list[GroupConfig]:
+        return self.groups
+
+    def num_classes(self) -> int:
+        return len(self.classes)
+
+    def make_collate_fn(self, device: torch.device | None = None):
+        """Convenience method — returns a ready-to-use collate_fn for this dataset."""
+        return partial(jet_collate_fn, group_configs=self.groups, device=device)
+
+    @staticmethod
+    def build_group_configs(config: dict) -> list[GroupConfig]:
+        """Helper to extract group configs from a full model config dict."""
+        return [GroupConfig(g) for g in config["inputs"]]

--- a/src/HH4b/neural_network/utils/feature_transform.py
+++ b/src/HH4b/neural_network/utils/feature_transform.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import torch
+
+
+class FeatureTransform:
+    @staticmethod
+    def normal(x: torch.Tensor, mean: float, std: float) -> torch.Tensor:
+        """Standardization (Z-score scaling). Best for Gaussian-like vars (e.g., eta)."""
+        if std == 0:
+            raise ValueError("Standard deviation cannot be zero for standardization.")
+        return (x - mean) / std
+
+    @staticmethod
+    def log_normal(x: torch.Tensor, mean: float, std: float, clamp_min: float = 0) -> torch.Tensor:
+        """Log-Normal scaling. Essential for high-pT tails and mass."""
+        # Adding 1 to avoid log(0) if variable can be 0
+        if std == 0:
+            raise ValueError("Standard deviation cannot be zero for standardization.")
+        clamp_min = max(clamp_min, 1e-12)  # Ensure clamp_min is non-negative for log scaling
+        x = torch.clamp(x, min=clamp_min)
+        return (torch.log(x) - mean) / std
+
+    @staticmethod
+    def min_max(x: torch.Tensor, min_val: float, max_val: float) -> torch.Tensor:
+        """Uniform scaling. Best for bounded variables (e.g., neural scores 0-1)."""
+        if max_val == min_val:
+            raise ValueError("Max and min values cannot be the same for min-max scaling.")
+        return (x - min_val) / (max_val - min_val)
+
+    @staticmethod
+    def digitize(x: torch.Tensor, bins: list) -> torch.Tensor:
+        """
+        Categorical binning.
+        Maps x to index based on [bins[i], bins[i+1]).
+        Example: bins=[0.8, 0.9, 1.0] ->
+        x < 0.8: 0 | 0.8 <= x < 0.9: 1 | 0.9 <= x < 1.0: 2 | x >= 1.0: 3
+        """
+        bins = torch.tensor(bins, device=x.device)
+        return torch.bucketize(x, bins)

--- a/src/HH4b/neural_network/utils/logger.py
+++ b/src/HH4b/neural_network/utils/logger.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
+
+RESET_SEQ = "\033[0m"
+COLOR_SEQ = "\033[1;%dm"
+BOLD_SEQ = "\033[1m"
+
+
+COLORS = {
+    "WARNING": YELLOW,
+    "INFO": WHITE,
+    "DEBUG": BLUE,
+    "CRITICAL": YELLOW,
+    "ERROR": RED,
+}
+
+
+def setup_logger(
+    name: str | None = None,
+    log_file: str | None = None,
+    log_level: str = "INFO",
+) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+
+    # Base message format
+    message_format = (
+        "[%(name)-10s][%(asctime)s][%(levelname)-10s]  %(message)s (%(filename)s:%(lineno)d)"
+    )
+
+    # File handler (no color or styling)
+    if log_file:
+        file_formatter = logging.Formatter(message_format)
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+
+    # Console handler (with color)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(log_level)
+    message = "[$BOLD%(name)-10s$RESET][%(asctime)s][%(levelname)-10s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
+    color_format = formatter_message(message, use_color=True)
+    console_handler.setFormatter(ColoredFormatter(color_format))
+    logger.addHandler(console_handler)
+
+    return logger
+
+
+def configure_logger(
+    logger: logging.Logger,
+    name: str | None = None,
+    log_file: str | None = None,
+    log_level: str | None = None,
+) -> None:
+    """
+    Configure or reconfigure a logger with the specified settings.
+    Only updates the parameters that are provided, keeping existing configuration otherwise.
+    """
+    # Store existing handlers configuration
+    existing_handlers = {"file": None, "console": None, "current_level": logger.level}
+
+    # Find and store existing handlers
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler):
+            existing_handlers["file"] = handler.baseFilename
+        elif isinstance(handler, logging.StreamHandler):
+            existing_handlers["console"] = handler
+
+    # Clear existing handlers
+    logger.handlers.clear()
+
+    # Update name if provided
+    if name is not None:
+        logger.name = name
+
+    # Update log level only if provided
+    if log_level is not None:
+        logger.setLevel(log_level)
+
+    # Base message format
+    message_format = (
+        "[%(name)-10s][%(asctime)s][%(levelname)-10s]  %(message)s (%(filename)s:%(lineno)d)"
+    )
+
+    # File handler (no color or styling)
+    # Use new log_file if provided, otherwise use existing one if there was one
+    file_to_use = log_file if log_file is not None else existing_handlers["file"]
+    if file_to_use:
+        file_formatter = logging.Formatter(message_format)
+        file_handler = logging.FileHandler(file_to_use)
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+
+    # Console handler (with color)
+    console_handler = logging.StreamHandler(sys.stdout)
+    # Use new log level if provided, otherwise use the logger's current level
+    console_handler.setLevel(log_level if log_level is not None else logger.level)
+    message = "[$BOLD%(name)-10s$RESET][%(asctime)s][%(levelname)-10s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
+    color_format = formatter_message(message, use_color=True)
+    console_handler.setFormatter(ColoredFormatter(color_format))
+    logger.addHandler(console_handler)
+
+
+class ColoredFormatter(logging.Formatter):
+    def __init__(self, msg: str, use_color: bool = True):
+        logging.Formatter.__init__(self, msg)
+        self.use_color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        levelname = record.levelname
+        if self.use_color and levelname in COLORS:
+            levelname_color = COLOR_SEQ % (30 + COLORS[levelname]) + levelname + RESET_SEQ
+            record.levelname = levelname_color
+        return logging.Formatter.format(self, record)
+
+
+def formatter_message(message: str, use_color: bool = True) -> str:
+    if use_color:
+        message = message.replace("$RESET", RESET_SEQ).replace("$BOLD", BOLD_SEQ)
+    else:
+        message = message.replace("$RESET", "").replace("$BOLD", "")
+    return message
+
+
+LOGGER = setup_logger(name="HH4b Training", log_level="INFO")

--- a/src/HH4b/neural_network/utils/roc.py
+++ b/src/HH4b/neural_network/utils/roc.py
@@ -1,0 +1,395 @@
+"""roc_utils.py — ROC curve computation and plotting for JetClassifier."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from pathlib import Path
+from typing import Any
+
+import matplotlib as mpl
+import numpy as np
+import torch
+from accelerate import Accelerator
+from matplotlib import pyplot as plt
+from sklearn.metrics import roc_curve
+
+_log = logging.getLogger(__name__)
+
+mpl.use("Agg")
+
+# ---------------------------------------------------------------------------
+# Palette
+# ---------------------------------------------------------------------------
+
+_COLORS = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00", "#a65628", "#f781bf"]
+_DASHES = [(6, 2), (3, 2), (1, 2)]  # long-dash, medium-dash, dotted
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+
+def compute_roc_metrics(
+    all_logits: torch.Tensor,  # (N, num_classes)
+    all_labels: torch.Tensor,  # (N,)
+    all_weights: torch.Tensor | None,  # (N,) or None
+    roc_group: dict[str, Any],
+    class_to_idx: dict[str, int],
+) -> dict[str, Any]:
+    """Compute ROC AUC and signal efficiencies at given background efficiencies.
+
+    Args:
+        all_logits:   Raw model logits for the full split.
+        all_labels:   Integer class labels.
+        all_weights:  Per-sample weights (or None).
+        roc_group:    One entry from config['training']['roc_groups'].
+        class_to_idx: Mapping from class name -> integer index.
+
+    Returns:
+        Dict with keys:
+            'auc'        : float
+            'sig_effs'   : list of (eps_b_target, eps_s_achieved) tuples
+            'fpr'        : np.ndarray   (background efficiency)
+            'tpr'        : np.ndarray   (signal efficiency)
+            'thresholds' : np.ndarray
+    """
+    signal_classes = roc_group["signal"]
+    background_classes = roc_group["background"]
+    target_bkg_effs: list[float] = roc_group.get("bkg_effs", [1e-1, 1e-2, 1e-3, 1e-4])
+
+    sig_indices = [class_to_idx[c] for c in signal_classes]
+    bkg_indices = [class_to_idx[c] for c in background_classes]
+
+    probs = torch.softmax(all_logits, dim=-1).cpu().numpy()  # (N, C)
+    labels_np = all_labels.cpu().numpy()  # (N,)
+    weights_np = all_weights.cpu().numpy() if all_weights is not None else None
+
+    is_sig = np.isin(labels_np, sig_indices)
+    is_bkg = np.isin(labels_np, bkg_indices)
+    keep = is_sig | is_bkg
+
+    probs = probs[keep]
+    is_sig = is_sig[keep]
+    weights_np = weights_np[keep] if weights_np is not None else None
+
+    n_sig = int(is_sig.sum())
+    n_bkg = int((~is_sig).sum())
+
+    # Weighted counts (what sklearn actually sees)
+    if weights_np is not None:
+        w_sig = float(weights_np[is_sig].sum())
+        w_bkg = float(weights_np[~is_sig].sum())
+    else:
+        w_sig, w_bkg = float(n_sig), float(n_bkg)
+
+    _log.debug(
+        f"Computing ROC metrics for roc_group '{roc_group['name']}': "
+        f"n_sig={n_sig:,} (w={w_sig:.3g})  n_bkg={n_bkg:,} (w={w_bkg:.3g})"
+    )
+
+    if n_sig == 0 or n_bkg == 0 or w_sig <= 0 or w_bkg <= 0:
+        warnings.warn(
+            f"roc_group '{roc_group['name']}': "
+            f"n_sig={n_sig:,} (w={w_sig:.3g}), n_bkg={n_bkg:,} (w={w_bkg:.3g}) — "
+            f"ROC is undefined. Signal classes: {signal_classes}.",
+            stacklevel=2,
+        )
+        nan = float("nan")
+        return {
+            "auc": nan,
+            "sig_effs": [(eps_b, nan) for eps_b in sorted(target_bkg_effs, reverse=True)],
+            "fpr": np.array([0.0, 1.0]),
+            "tpr": np.array([0.0, 1.0]),
+            "thresholds": np.array([1.0, 0.0]),
+        }
+
+    # Score = sum of signal class softmax probabilities
+    score = probs[:, sig_indices].sum(axis=1)
+    binary_label = is_sig.astype(np.float32)
+
+    fpr, tpr, thresholds = roc_curve(binary_label, score, sample_weight=weights_np)
+
+    auc = float(abs(np.trapezoid(tpr, fpr)))
+
+    # List of (eps_b_target, eps_s_achieved), sorted descending by eps_b
+    sig_effs: list[tuple[float, float]] = []
+    for eps_b in sorted(target_bkg_effs, reverse=True):
+        valid = fpr <= eps_b + 1e-12
+        eps_s = float(tpr[valid][-1]) if valid.any() else 0.0
+        sig_effs.append((eps_b, eps_s))
+
+    return {
+        "auc": auc,
+        "sig_effs": sig_effs,
+        "fpr": fpr,
+        "tpr": tpr,
+        "thresholds": thresholds,
+    }
+
+
+def compute_roc_per_signal(
+    all_logits: torch.Tensor,
+    all_labels: torch.Tensor,
+    all_weights: torch.Tensor | None,
+    sig_keys: list[str],
+    bg_keys: list[str],
+    class_to_idx: dict[str, int],
+    bkg_effs: list[float] | None = None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Compute ROC curves for each signal vs each background + merged background.
+
+    Like TrainBDT.py: one figure per signal, with curves for each individual
+    background and a "merged" (all backgrounds) curve.
+
+    Returns:
+        {sig_key: {bkg_label: roc_result_dict, ...}, ...}
+        where bkg_label is each bg_key plus "merged".
+    """
+    if bkg_effs is None:
+        bkg_effs = [1e-1, 1e-2, 1e-3, 1e-4]
+
+    all_results: dict[str, dict[str, dict[str, Any]]] = {}
+
+    for sig_key in sig_keys:
+        sig_results: dict[str, dict[str, Any]] = {}
+
+        # Individual backgrounds
+        for bkg_key in bg_keys:
+            roc_group = {
+                "name": f"{sig_key}_vs_{bkg_key}",
+                "signal": [sig_key],
+                "background": [bkg_key],
+                "bkg_effs": bkg_effs,
+            }
+            sig_results[bkg_key] = compute_roc_metrics(
+                all_logits, all_labels, all_weights, roc_group, class_to_idx
+            )
+
+        # Merged (all backgrounds)
+        roc_group_merged = {
+            "name": f"{sig_key}_vs_merged",
+            "signal": [sig_key],
+            "background": bg_keys,
+            "bkg_effs": bkg_effs,
+        }
+        sig_results["merged"] = compute_roc_metrics(
+            all_logits, all_labels, all_weights, roc_group_merged, class_to_idx
+        )
+
+        all_results[sig_key] = sig_results
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def _format_exp(val: float) -> str:
+    """Format e.g. 1e-2 as '10^{-2}' for matplotlib LaTeX."""
+    exp = round(np.log10(val))
+    return rf"10^{{{exp}}}"
+
+
+def _make_roc_figure(
+    roc_results: dict[str, dict[str, Any]],
+    epoch: int | str,
+    title: str | None = None,
+) -> plt.Figure:
+    """Build and return the matplotlib Figure.
+
+    Style follows TrainBDT.py: x = signal eff (tpr), y = background eff (fpr),
+    log-y scale, x-axis spans [0, 1.0], operating-point markers with labels for
+    signal efficiency at key background efficiencies.
+    """
+    fig, ax = plt.subplots(figsize=(18, 12))
+
+    th_colours = ["#9381FF", "#1f78b4", "#a6cee3", "cyan", "blue", "#ff7f00"]
+
+    for i, (name, res) in enumerate(roc_results.items()):
+        color = _COLORS[i % len(_COLORS)]
+
+        # ROC curve: x = signal eff (tpr), y = background eff (fpr), log-y
+        ax.plot(
+            res["tpr"],
+            res["fpr"],
+            lw=2,
+            color=color,
+            label=rf"{name}  AUC $=$ {res['auc']:.4f}",
+            zorder=3,
+        )
+
+        # Operating-point markers only for the last curve (merged)
+        is_last = i == len(roc_results) - 1
+        if is_last:
+            for j, (eps_b, eps_s) in enumerate(res["sig_effs"]):
+                if not eps_s or np.isnan(eps_s) or eps_s <= 0:
+                    continue
+                th_color = th_colours[j % len(th_colours)]
+                op_label = (
+                    rf"$\varepsilon_s = {eps_s:.4f}$  @  "
+                    rf"$\varepsilon_b = {_format_exp(eps_b)}$"
+                )
+                ax.scatter(
+                    eps_s,
+                    eps_b,
+                    marker="o",
+                    s=40,
+                    color=th_color,
+                    label=op_label,
+                    zorder=100,
+                )
+                ax.vlines(
+                    x=eps_s,
+                    ymin=0,
+                    ymax=eps_b,
+                    color=th_color,
+                    linestyles="dashed",
+                    alpha=0.5,
+                )
+                ax.hlines(
+                    y=eps_b,
+                    xmin=0,
+                    xmax=eps_s,
+                    color=th_color,
+                    linestyles="dashed",
+                    alpha=0.5,
+                )
+
+    ax.set_xlabel("Signal efficiency", fontsize=13)
+    ax.set_ylabel("Background efficiency", fontsize=13)
+    ax.set_yscale("log")
+    ax.set_xlim(0.0, 1.0)
+
+    all_bkg_effs = [
+        eps_b for res in roc_results.values() for eps_b, _ in res["sig_effs"] if eps_b > 0
+    ]
+    ax.set_ylim(min(all_bkg_effs) * 0.3 if all_bkg_effs else 1e-5, 1.5)
+
+    ax.xaxis.grid(True, which="major")
+    ax.yaxis.grid(True, which="major")
+    if title is not None:
+        ax.set_title(title, fontsize=13, pad=10)
+    else:
+        epoch_str = f"{epoch:04d}" if isinstance(epoch, int) else str(epoch)
+        ax.set_title(f"ROC Curves -- Epoch {epoch_str}", fontsize=13, pad=10)
+    ax.legend(fontsize=9, loc="upper left", framealpha=0.85, edgecolor="0.7")
+
+    fig.tight_layout()
+    return fig
+
+
+def save_roc_plot(
+    roc_results: dict[str, dict[str, Any]],
+    output_dir: Path,
+    epoch: int | str,
+    title: str | None = None,
+    filename: str | None = None,
+) -> None:
+    """Save ROC curves as PNG and PDF under ``output_dir/``.
+
+    Args:
+        filename: If provided, use this as the stem (without extension).
+                  Otherwise defaults to ``roc_epoch_XXXX``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    fig = _make_roc_figure(roc_results, epoch, title=title)
+    if filename is not None:
+        stem = output_dir / filename
+    else:
+        epoch_str = f"{epoch:04d}" if isinstance(epoch, int) else str(epoch)
+        stem = output_dir / f"roc_epoch_{epoch_str}"
+    fig.savefig(f"{stem}.pdf", bbox_inches="tight")
+    fig.savefig(f"{stem}.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_roc_per_signal(
+    all_results: dict[str, dict[str, dict[str, Any]]],
+    output_dir: Path,
+    epoch: int | str,
+    split: str = "val",
+) -> None:
+    """Save one ROC figure per signal class.
+
+    Each figure has curves for each individual background + merged.
+    Follows TrainBDT.py convention.
+
+    Args:
+        all_results: Output from ``compute_roc_per_signal``.
+        output_dir:  Base directory for saving plots.
+        epoch:       Current epoch (used for filenames).
+        split:       Split name (e.g. "val", "test").
+    """
+    epoch_str = f"{epoch:04d}" if isinstance(epoch, int) else str(epoch)
+
+    for sig_key, bkg_results in all_results.items():
+        sig_dir = output_dir / sig_key
+        sig_dir.mkdir(parents=True, exist_ok=True)
+
+        title = f"{sig_key} ROC -- {split} -- Epoch {epoch_str}"
+        filename = f"roc_{split}_epoch_{epoch_str}"
+        save_roc_plot(bkg_results, sig_dir, epoch, title=title, filename=filename)
+        _log.info(f"  ROC plot saved → {sig_dir}/{filename}.[png|pdf]")
+
+
+# ---------------------------------------------------------------------------
+# Accumulator
+# ---------------------------------------------------------------------------
+
+
+class ScoreAccumulator:
+    """Collects (logits, labels, weights) across batches for later ROC computation."""
+
+    def __init__(self) -> None:
+        self._logits: list[torch.Tensor] = []
+        self._labels: list[torch.Tensor] = []
+        self._weights: list[torch.Tensor] = []
+        self._has_weights = False
+
+    def update(
+        self,
+        logits: torch.Tensor,
+        labels: torch.Tensor,
+        weights: torch.Tensor | None = None,
+    ) -> None:
+        self._logits.append(logits.detach().cpu())
+        self._labels.append(labels.detach().cpu())
+        if weights is not None:
+            self._weights.append(weights.detach().cpu())
+            self._has_weights = True
+
+    def finalize(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Returns (all_logits, all_labels, all_weights_or_None)."""
+        logits = torch.cat(self._logits, dim=0)
+        labels = torch.cat(self._labels, dim=0)
+        weights = torch.cat(self._weights, dim=0) if self._has_weights else None
+
+        _log.debug(
+            f"Finalized ScoreAccumulator: {len(logits):,} samples, "
+            f"with labels {torch.unique(labels)} "
+            f"{'with' if weights is not None else 'without'} weights."
+        )
+
+        return logits, labels, weights
+
+    def gather(self, accelerator: Accelerator) -> ScoreAccumulator:
+        logits, labels, weights = self.finalize()
+
+        logits = accelerator.gather(logits.to(accelerator.device))
+        labels = accelerator.gather(labels.to(accelerator.device))
+        if weights is not None:
+            weights = accelerator.gather(weights.to(accelerator.device))
+
+        _log.debug(
+            f"Gathered ScoreAccumulator across processes: {len(logits):,} samples, "
+            f"with labels {torch.unique(labels)} "
+            f"{'with' if weights is not None else 'without'} weights."
+        )
+
+        new = ScoreAccumulator()
+        new.update(logits.cpu(), labels.cpu(), weights.cpu() if weights is not None else None)
+        return new

--- a/src/HH4b/neural_network/utils/scheduler.py
+++ b/src/HH4b/neural_network/utils/scheduler.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import (
+    ConstantLR,
+    CosineAnnealingLR,
+    CosineAnnealingWarmRestarts,
+    LambdaLR,
+    LinearLR,
+    ReduceLROnPlateau,
+    SequentialLR,
+    StepLR,
+    _LRScheduler,
+)
+
+from .ckpt import get_checkpoints_path
+from .logger import LOGGER
+
+
+def get_cosine_schedule(
+    iter: int,
+    total_iters: int,
+    base_value: float = 1e-3,
+    final_value: float = 0.0,
+):
+    # Clamp iter to [0, total_iters] to avoid returning nonsense values if
+    # last_epoch overshoots (e.g. due to a double-step or off-by-one on resume).
+    iter = max(0, min(iter, total_iters))
+    return final_value + 0.5 * (base_value - final_value) * (
+        1 + math.cos(math.pi * iter / total_iters)
+    )
+
+
+def get_scheduler(
+    optimizer: Optimizer,
+    config: dict,
+) -> _LRScheduler | ReduceLROnPlateau | None:
+    """
+    Get the scheduler. If not specified, will give None.
+    """
+
+    scheduler_config = config["training"].get("scheduler")
+    if not scheduler_config:
+        LOGGER.info("No scheduler specified in config. Returning None.")
+        return None
+
+    scheduler_name = scheduler_config.get("name", "").lower()
+    scheduler_params = scheduler_config.get("params", {})
+
+    if scheduler_name == "steplr":
+        scheduler = StepLR(optimizer, **scheduler_params)
+    elif scheduler_name == "reducelronplateau":
+        scheduler = ReduceLROnPlateau(optimizer, **scheduler_params)
+    elif scheduler_name == "cosineannealinglr":
+        scheduler = CosineAnnealingLR(optimizer, **scheduler_params)
+    elif scheduler_name == "cosineannealingwarmrestarts":
+        scheduler = CosineAnnealingWarmRestarts(optimizer, **scheduler_params)
+    elif scheduler_name == "linearlr":
+        scheduler = LinearLR(optimizer, **scheduler_params)
+    elif scheduler_name == "constantlr":
+        scheduler = ConstantLR(optimizer, **scheduler_params)
+    elif scheduler_name == "cosinescheduler":
+        scheduler = LambdaLR(
+            optimizer,
+            lr_lambda=lambda it: get_cosine_schedule(iter=it, **scheduler_params),
+        )
+    elif scheduler_name == "sequentiallr":
+        scheduler = _create_sequential_scheduler(optimizer, scheduler_params)
+        if not scheduler:
+            return None
+    else:
+        LOGGER.warning(f"Unknown scheduler type: {scheduler_name}. Returning None.")
+        return None
+
+    LOGGER.info(f"Created scheduler: {scheduler.__class__.__name__}")
+    LOGGER.debug(f"Scheduler parameters: {scheduler_params}")
+
+    # Load scheduler state if specified in config
+    epoch = config["training"].get("load_epoch")
+    if epoch:
+        ckpt_path = get_checkpoints_path(config=config, epoch_num=epoch)
+        try:
+            state_dict = torch.load(ckpt_path)
+        except RuntimeError as e:
+            LOGGER.error(f"Failed to load checkpoint {ckpt_path}: {e}. Trying cpu.")
+            state_dict = torch.load(ckpt_path, map_location="cpu")
+        _load_scheduler_state(scheduler, state_dict)
+
+    return scheduler
+
+
+def _create_sequential_scheduler(optimizer: Optimizer, scheduler_params: dict):
+    """Create a SequentialLR scheduler from config."""
+    schedulers_config = scheduler_params.get("schedulers", [])
+    milestones = scheduler_params.get("milestones", [])
+
+    if not schedulers_config:
+        LOGGER.error("SequentialLR requires 'schedulers' list in params")
+        return None
+
+    if not milestones:
+        LOGGER.error("SequentialLR requires 'milestones' list in params")
+        return None
+
+    # Create individual schedulers
+    schedulers = []
+    for i, sched_config in enumerate(schedulers_config):
+        sched_name = sched_config.get("name", "").lower()
+        sched_params = sched_config.get("params", {})
+
+        if sched_name == "steplr":
+            scheduler = StepLR(optimizer, **sched_params)
+        elif sched_name == "reducelronplateau":
+            LOGGER.error("ReduceLROnPlateau cannot be used in SequentialLR")
+            return None
+        elif sched_name == "cosineannealinglr":
+            scheduler = CosineAnnealingLR(optimizer, **sched_params)
+        elif sched_name == "cosineannealingwarmrestarts":
+            scheduler = CosineAnnealingWarmRestarts(optimizer, **sched_params)
+        elif sched_name == "linearlr":
+            scheduler = LinearLR(optimizer, **sched_params)
+        elif sched_name == "constantlr":
+            scheduler = ConstantLR(optimizer, **sched_params)
+        elif sched_name == "cosinescheduler":
+            scheduler = LambdaLR(
+                optimizer,
+                lr_lambda=lambda it, p=sched_params: get_cosine_schedule(it, **p),
+            )
+        else:
+            LOGGER.error(f"Unknown scheduler type in SequentialLR: {sched_name}")
+            return None
+
+        schedulers.append(scheduler)
+        LOGGER.info(f"Created scheduler {i} for SequentialLR: {scheduler.__class__.__name__}")
+
+    return SequentialLR(optimizer, schedulers=schedulers, milestones=milestones)
+
+
+def _load_scheduler_state(
+    scheduler: _LRScheduler | ReduceLROnPlateau,
+    state_dict: dict,
+) -> None:
+    if "scheduler" not in state_dict:
+        LOGGER.warning(
+            "Checkpoint file does not contain scheduler state. Starting with fresh scheduler."
+        )
+        return
+
+    if isinstance(scheduler, ReduceLROnPlateau):
+        scheduler.best = state_dict["scheduler"].get("best", scheduler.best)
+        scheduler.num_bad_epochs = state_dict["scheduler"].get(
+            "num_bad_epochs", scheduler.num_bad_epochs
+        )
+        LOGGER.info(
+            f"Loaded ReduceLROnPlateau state: best={scheduler.best}, "
+            f"num_bad_epochs={scheduler.num_bad_epochs}"
+        )
+    else:
+        scheduler.load_state_dict(state_dict["scheduler"])
+        LOGGER.info(f"Loaded scheduler state from checkpoint (last_epoch={scheduler.last_epoch})")
+
+        # After restoring scheduler state, the optimizer's param_groups['lr'] will
+        # be whatever was saved in the optimizer state dict (the raw decayed value).
+        # We need to recompute LRs from the scheduler's restored last_epoch and
+        # write them back into the optimizer, so the two are consistent.
+        #
+        # _get_closed_form_lr() is not available on all schedulers, so we use
+        # the safer approach: temporarily step the scheduler back one tick and
+        # re-step it forward to trigger a recompute.
+        #
+        # The cleanest portable approach: directly call get_lr() via the internal
+        # mechanism by computing LRs and writing them to param groups.
+        _sync_optimizer_lr_from_scheduler(scheduler)
+
+
+def _sync_optimizer_lr_from_scheduler(scheduler: _LRScheduler) -> None:
+    """
+    After load_state_dict, the optimizer param_group LRs may be stale (from the
+    optimizer state dict). This recomputes the correct LR from the scheduler's
+    restored last_epoch and writes it back into the optimizer param groups.
+
+    Strategy: decrement last_epoch by 1, call .step() to recompute and apply LRs,
+    which increments last_epoch back to where it was. Net effect: LRs in optimizer
+    are recomputed correctly from the restored scheduler state.
+    """
+    # Save the current last_epoch
+    saved_last_epoch = scheduler.last_epoch
+
+    # Decrement so that .step() brings us back to saved_last_epoch
+    scheduler.last_epoch = saved_last_epoch - 1
+
+    # Suppress the "Detected call of lr_scheduler.step() before optimizer.step()"
+    # warning that PyTorch emits if step() is called out of the normal order.
+    import warnings  # noqa: PLC0415
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        scheduler.step()
+
+    # Verify
+    restored_lrs = [pg["lr"] for pg in scheduler.optimizer.param_groups]
+    LOGGER.info(
+        f"Resynced optimizer LRs from scheduler (last_epoch={scheduler.last_epoch}): {restored_lrs}"
+    )


### PR DESCRIPTION
Adds `src/HH4b/neural_network/` — a transformer-based classifier as an alternative HH→4b discriminant.

- `JetClassifier`: per-group embeddings (AK8/AK4/VBF/event-level) → `TransformerEncoder` → MLP head.
- Data prep, training/eval entry points, YAML configs, ROC utilities. Self-contained subpackage — see `neural_network/README.md`.

One of a 3-PR split of the `nanov15-bdt` work (transformer / ABCDnn-BDT / FOM-scan). Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
