### PR TITLE
Support 2024/2025 eras (NanoV15) in postprocessing and datacards

### DIFF
--- a/src/HH4b/hh_vars.py
+++ b/src/HH4b/hh_vars.py
@@ -19,6 +19,7 @@ LUMI = {
     "2023BPix": 9692.1,
     "2023All": 27776.5,
     "2022-2023": 62428.6,
+    "2022-2025": 261808.6,
     "2024": 108960.0,
     "2024C": 7240.0,
     "2024D": 7960.0,
@@ -31,6 +32,7 @@ LUMI = {
     "2025E": 14000.0,
     "2025D": 25290.0,
     "2025F": 30350.0,
+    "2025": 90420.0,  # ongoing
     # 2025G ongoing
     "2018": 59830.0,
     "2017": 41480.0,
@@ -43,7 +45,10 @@ DATA_SAMPLES = ["JetMET", "Muon", "EGamma"]
 
 # sample key -> list of samples or selectors
 common_samples_bg = {
-    "qcd": ["QCD_HT"],
+    # Support both naming schemes seen on disk across eras:
+    # - 2022/2023: QCD-4Jets_HT-*
+    # - 2024+:     QCD_HT-*
+    "qcd": ["QCD-4Jets_HT", "QCD_HT-"],
     "data": [f"{key}_Run" for key in DATA_SAMPLES],
     "ttbar": ["TTto4Q", "TTto2L2Nu", "TTtoLNu2Q"],
     "vhtobb": [
@@ -57,153 +62,96 @@ common_samples_bg = {
         # "ggZH_Hto2B_Zto2Nu_M-125",
     ],
     "novhhtobb": ["GluGluHto2B_PT-200_M-125", "VBFHto2B_M-125_dipoleRecoilOn"],
-    "tthtobb": ["ttHto2B_M-125"],
-    "zz": ["ZZ"],
-    "nozzdiboson": ["WW", "WZ"],
-    "vjets": ["Wto2Q-2Jets_PTQQ", "Zto2Q-2Jets_PTQQ"],
+    "tthtobb": ["ttHto2B_M-125", "TTHto2B_M-125"],
+    # Use exact-match selectors to avoid pulling in ZZto*/WWto*/WZto* sub-samples.
+    "zz": ["ZZ?"],
+    "nozzdiboson": ["WW?", "WZ?"],
+    "vjets": [
+        "Wto2Q-2Jets_PTQQ",
+        "Zto2Q-2Jets_PTQQ",
+        "Wto2Q-2Jets_Bin-PTQQ-",
+        "Zto2Q-2Jets_Bin-PTQQ-",
+    ],
 }
 
 common_samples_sig = {}
 
 samples_run3_sig = {
     "2022": {
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-kv1p74-k2v1p37-kl14p4": [
-            "VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": [
-            "VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": [
-            "VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": [
-            "VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": [
-            "VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": [
-            "VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": [
-            "VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": [
-            "VBFHHto4B_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
+        # Use prefix selectors so both short and fully qualified dataset names match.
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00"],
+        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00"],
+        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00"],
+        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00"],
+        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1"],
+        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1"],
+        "vbfhh4b-kv1p74-k2v1p37-kl14p4": ["VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4"],
+        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": ["VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2"],
+        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": ["VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3"],
+        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": ["VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43"],
+        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": ["VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94"],
+        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": ["VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36"],
+        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": ["VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39"],
+        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": ["VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96"],
         # "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
-        #     "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
+        #    "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
         # ],
     },
     "2022EE": {
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-kv1p74-k2v1p37-kl14p4": [
-            "VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": [
-            "VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": [
-            "VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": [
-            "VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": [
-            "VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": [
-            "VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": [
-            "VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": [
-            "VBFHHto4B_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00"],
+        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00"],
+        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00"],
+        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00"],
+        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1"],
+        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1"],
+        "vbfhh4b-kv1p74-k2v1p37-kl14p4": ["VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4"],
+        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": ["VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2"],
+        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": ["VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3"],
+        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": ["VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43"],
+        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": ["VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94"],
+        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": ["VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36"],
+        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": ["VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39"],
+        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": ["VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96"],
         # "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
-        #     "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
+        #    "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
         # ],
     },
     "2023": {
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-kv1p74-k2v1p37-kl14p4": [
-            "VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": [
-            "VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": [
-            "VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": [
-            "VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": [
-            "VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": [
-            "VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": [
-            "VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": [
-            "VBFHHto4B_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00"],
+        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00"],
+        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00"],
+        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00"],
+        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1"],
+        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1"],
+        "vbfhh4b-kv1p74-k2v1p37-kl14p4": ["VBFHHto4B_CV_1p74_C2V_1p37_C3_14p4"],
+        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": ["VBFHHto4B_CV_m0p012_C2V_0p030_C3_10p2"],
+        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": ["VBFHHto4B_CV_m0p758_C2V_1p44_C3_m19p3"],
+        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": ["VBFHHto4B_CV_m0p962_C2V_0p959_C3_m1p43"],
+        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": ["VBFHHto4B_CV_m1p21_C2V_1p94_C3_m0p94"],
+        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": ["VBFHHto4B_CV_m1p60_C2V_2p72_C3_m1p36"],
+        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": ["VBFHHto4B_CV_m1p83_C2V_3p57_C3_m3p39"],
+        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": ["VBFHHto4B_CV_2p12_C2V_3p87_C3_m5p96"],
         # "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
-        #     "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
+        #    "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
         # ],
     },
     "2023BPix": {
-        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV?"],
-        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8"],
-        "vbfhh4b-kv1p74-k2v1p37-kl14p4": [
-            "VBFHHto4B_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": [
-            "VBFHHto4B_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": [
-            "VBFHHto4B_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": [
-            "VBFHHto4B_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": [
-            "VBFHHto4B_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": [
-            "VBFHHto4B_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": [
-            "VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
-        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": [
-            "VBFHHto4B_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
-        ],
+        "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00"],
+        "hh4b-kl0": ["GluGlutoHHto4B_kl-0p00_kt-1p00_c2-0p00"],
+        "hh4b-kl2p45": ["GluGlutoHHto4B_kl-2p45_kt-1p00_c2-0p00"],
+        "hh4b-kl5": ["GluGlutoHHto4B_kl-5p00_kt-1p00_c2-0p00"],
+        "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1"],
+        "vbfhh4b-k2v0": ["VBFHHto4B_CV_1_C2V_0_C3_1"],
+        "vbfhh4b-kv1p74-k2v1p37-kl14p4": ["VBFHHto4B_CV_1p74_C2V_1p37_C3_14p4"],
+        "vbfhh4b-kvm0p012-k2v0p03-kl10p2": ["VBFHHto4B_CV_m0p012_C2V_0p030_C3_10p2"],
+        "vbfhh4b-kvm0p758-k2v1p44-klm19p3": ["VBFHHto4B_CV_m0p758_C2V_1p44_C3_m19p3"],
+        "vbfhh4b-kvm0p962-k2v0p959-klm1p43": ["VBFHHto4B_CV_m0p962_C2V_0p959_C3_m1p43"],
+        "vbfhh4b-kvm1p21-k2v1p94-klm0p94": ["VBFHHto4B_CV_m1p21_C2V_1p94_C3_m0p94"],
+        "vbfhh4b-kvm1p6-k2v2p72-klm1p36": ["VBFHHto4B_CV_m1p60_C2V_2p72_C3_m1p36"],
+        "vbfhh4b-kvm1p83-k2v3p57-klm3p39": ["VBFHHto4B_CV_m1p83_C2V_3p57_C3_m3p39"],
+        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": ["VBFHHto4B_CV_2p12_C2V_3p87_C3_m5p96"],
         # "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
-        #     "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
+        #    "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
         # ],
     },
     "2024": {
@@ -234,9 +182,12 @@ samples_run3_sig = {
         "vbfhh4b-kvm1p83-k2v3p57-klm3p39": [
             "VBFHHto4B_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8"
         ],
-        "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
+        "vbfhh4b-kvm2p12-k2v3p87-klm5p96": [
             "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
         ],
+        # "vbfhh4b-kv2p12-k2v3p87-klm5p96": [
+        #    "VBFHHto4B_CV-2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8"
+        # ],
     },
     "2025": {},
 }
@@ -259,6 +210,7 @@ samples_run3 = {
         **samples_run3_sig["2023BPix"],
     },
     "2024": {
+        **common_samples_bg,
         "data": [
             "JetMET_Run2024B",
             "JetMET_Run2024C",
@@ -274,7 +226,7 @@ samples_run3 = {
     "2025": {
         "data": [
             "JetMET_Run2025C",
-            "JetMET_Run2025D",
+            # "JetMET_Run2025D",  # missing required AK8PFJet* trigger columns in current skim
             "JetMET_Run2025E",
             "JetMET_Run2025F",
             "JetMET_Run2025G",
@@ -287,13 +239,13 @@ samples_2018 = {
         "GluGlutoHHto4B_cHHH1_TuneCP5_PSWeights_13TeV-powheg-pythia8",
     ],
     "qcd": [
-        "QCD_HT-1000to1500-13TeV",
-        "QCD_HT-1500to2000-13TeV",
-        "QCD_HT-2000toInf-13TeV",
-        "QCD_HT-200to300-13TeV",
-        "QCD_HT-300to500-13TeV",
-        "QCD_HT-500to700-13TeV",
-        "QCD_HT-700to1000-13TeV",
+        "QCD-4Jets_HT-1000to1500-13TeV",
+        "QCD-4Jets_HT-1500to2000-13TeV",
+        "QCD-4Jets_HT-2000toInf-13TeV",
+        "QCD-4Jets_HT-200to300-13TeV",
+        "QCD-4Jets_HT-300to500-13TeV",
+        "QCD-4Jets_HT-500to700-13TeV",
+        "QCD-4Jets_HT-700to1000-13TeV",
     ],
     "data": [
         "Run2018A",

--- a/src/HH4b/postprocessing/CreateDatacard.py
+++ b/src/HH4b/postprocessing/CreateDatacard.py
@@ -115,7 +115,7 @@ parser.add_argument(
     "--year",
     type=str,
     default="2022-2023",
-    choices=hh_years + ["2022-2023"],
+    choices=hh_years + ["2022-2023", "2022-2025"],
     help="years to make datacards for",
 )
 parser.add_argument(
@@ -219,8 +219,13 @@ for key in all_sig_keys:
 all_mc = list(mc_samples.keys())
 
 
-years = hh_years if args.year == "2022-2023" else [args.year]
-full_lumi = LUMI[args.year]
+if args.year == "2022-2023":
+    years = ["2022", "2022EE", "2023", "2023BPix"]
+elif args.year == "2022-2025":
+    years = hh_years
+else:
+    years = [args.year]
+full_lumi = sum(LUMI[y] for y in years)
 
 jmsr_keys = sig_keys + ["vhtobb", "zz", "nozzdiboson"]
 
@@ -261,14 +266,26 @@ nuisance_params = {
         value_down={"hh4b": 0.77, "hh4b-kl0": 0.82, "hh4b-kl2p45": 0.75, "hh4b-kl5": 0.87},
         diff_samples=True,
     ),
-    # weight lumi uncertainties by corresponding integrated lumi
-    "lumi_2022": Syst(
-        prior="lnN", samples=all_mc, value=1 + 0.014 * LUMI["2022All"] / LUMI["2022-2023"]
-    ),
-    "lumi_2023": Syst(
-        prior="lnN", samples=all_mc, value=1 + 0.013 * LUMI["2023All"] / LUMI["2022-2023"]
-    ),
 }
+# Lumi uncertainties, weighted by fraction of data in each era (only for eras in this fit)
+if any(y in years for y in ["2022", "2022EE"]):
+    _lumi_2022 = sum(LUMI[y] for y in ["2022", "2022EE"] if y in years)
+    nuisance_params["lumi_2022"] = Syst(
+        prior="lnN", samples=all_mc, value=1 + 0.014 * _lumi_2022 / full_lumi
+    )
+if any(y in years for y in ["2023", "2023BPix"]):
+    _lumi_2023 = sum(LUMI[y] for y in ["2023", "2023BPix"] if y in years)
+    nuisance_params["lumi_2023"] = Syst(
+        prior="lnN", samples=all_mc, value=1 + 0.013 * _lumi_2023 / full_lumi
+    )
+if "2024" in years:
+    nuisance_params["lumi_2024"] = Syst(
+        prior="lnN", samples=all_mc, value=1 + 0.012 * LUMI["2024"] / full_lumi
+    )
+if "2025" in years:
+    nuisance_params["lumi_2025"] = Syst(
+        prior="lnN", samples=all_mc, value=1 + 0.012 * LUMI["2025"] / full_lumi
+    )
 if not args.thu_hh:
     del nuisance_params["THU_HH"]
 
@@ -359,6 +376,8 @@ uncorr_year_shape_systs = {
             "2022EE": ["2022EE"],
             "2023": ["2023"],
             "2023BPix": ["2023BPix"],
+            "2024": ["2024"],
+            "2025": ["2025"],
         },
     ),
     "JMS": Syst(
@@ -370,6 +389,8 @@ uncorr_year_shape_systs = {
             "2022EE": ["2022EE"],
             "2023": ["2023"],
             "2023BPix": ["2023BPix"],
+            "2024": ["2024"],
+            "2025": ["2025"],
         },
     ),
     "JMR": Syst(
@@ -381,6 +402,8 @@ uncorr_year_shape_systs = {
             "2022EE": ["2022EE"],
             "2023": ["2023"],
             "2023BPix": ["2023BPix"],
+            "2024": ["2024"],
+            "2025": ["2025"],
         },
     ),
 }
@@ -393,7 +416,12 @@ for i in range(len(ttsf_xbb_bins) - 1):
         prior="shape",
         samples=["ttbar"],
         convert_shape_to_lnN=True,
-        uncorr_years={"2022": ["2022", "2022EE"], "2023": ["2023", "2023BPix"]},
+        uncorr_years={
+            "2022": ["2022", "2022EE"],
+            "2023": ["2023", "2023BPix"],
+            "2024": ["2024"],
+            "2025": ["2025"],
+        },
     )
 TXbb_pt_corr_bins = txbbsfs_decorr_pt_bins.get(args.txbb, txbbsfs_decorr_pt_bins["glopart-v2"])
 TXbb_wps = txbbsfs_decorr_txbb_wps.get(args.txbb, txbbsfs_decorr_txbb_wps["glopart-v2"])
@@ -410,6 +438,8 @@ for wp in TXbb_wps:
             uncorr_years={
                 "2022": ["2022", "2022EE"],
                 "2023": ["2023", "2023BPix"],
+                "2024": ["2024"],
+                "2025": ["2025"],
             },
         )
 
@@ -429,6 +459,12 @@ if args.ttbar_rate_param:
     for key in list(uncorr_year_shape_systs.keys()):
         if "ttbarSF" in key:
             del uncorr_year_shape_systs[key]
+
+# Filter uncorr_years to only include eras being processed in this run
+for syst in uncorr_year_shape_systs.values():
+    syst.uncorr_years = {
+        label: yrs for label, yrs in syst.uncorr_years.items() if any(y in years for y in yrs)
+    }
 
 shape_systs_dict = {}
 for skey, syst in corr_year_shape_systs.items():

--- a/src/HH4b/postprocessing/PlotFits.py
+++ b/src/HH4b/postprocessing/PlotFits.py
@@ -95,11 +95,11 @@ def plot_fits(args):
         "fail": "QCD CR",
     }
     ylims = {
-        "passvbf": 12,
-        "passbin1": 10,
-        "passbin2": 40,
-        "passbin3": 300,
-        "fail": 300000,
+        "passvbf": 36,
+        "passbin1": 30,
+        "passbin2": 120,
+        "passbin3": 900,
+        "fail": 1500000,
     }
 
     if args.regions == "all":
@@ -172,7 +172,7 @@ def plot_fits(args):
             )
             bgerrs[shape][region] = templates["TotalBkg"].errors()
 
-    year = "2022-2023"
+    year = "2022-2025"
     pass_ratio_ylims = [0, 2]
     fail_ratio_ylims = [0, 2]
 

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -69,19 +69,6 @@ mpl.rcParams["grid.linewidth"] = 0.5
 mpl.rcParams["figure.dpi"] = 400
 mpl.rcParams["figure.edgecolor"] = "none"
 
-# modify samples run3
-for year in samples_run3:
-    samples_run3[year]["qcd"] = [
-        "QCD_HT-1000to1200",
-        "QCD_HT-1200to1500",
-        "QCD_HT-1500to2000",
-        "QCD_HT-2000",
-        # "QCD_HT-200to400",
-        "QCD_HT-400to600",
-        "QCD_HT-600to800",
-        "QCD_HT-800to1000",
-    ]
-
 selection_regions = {
     "pass_vbf": Region(
         cuts={
@@ -511,7 +498,31 @@ def load_process_run3_samples(
 
     # define cutflows
     samples_year = list(samples_run3[year].keys())
-    if not control_plots and not args.bdt_roc:
+
+    # MC fallback and luminosity scaling for years without dedicated MC (e.g. 2025).
+    # We split 2024 MC 50/50: half for 2024 templates, half for 2025 templates.
+    # Split is deterministic via (run + luminosityBlock + event) % 2.
+    mc_fallback_year = None
+    mc_lumi_scale = 1.0
+    mc_split_half = None  # 0 = use for 2024, 1 = use for 2025
+    if year == "2025":
+        # 2025 has no MC: use 2024 MC (other half), scale yields to 2025 lumi.
+        mc_fallback_year = "2024"
+        target_lumi = hh_vars.LUMI.get(year)
+        if target_lumi is None:
+            target_lumi = sum(v for k, v in hh_vars.LUMI.items() if k.startswith("2025"))
+        # LUMI SCALING: MC weights are norm'd to source-year lumi; multiply by target/source
+        # to get yields appropriate for 2025.
+        mc_lumi_scale = target_lumi / hh_vars.LUMI[mc_fallback_year]
+        mc_split_half = 1  # use events with (run+lumi+evt)%2 == 1
+        samples_year = [hh_vars.data_key] + [
+            k for k in samples_run3[mc_fallback_year] if k != hh_vars.data_key
+        ]
+    elif year == "2024":
+        # Use half of 2024 MC for 2024 templates; the other half is reserved for 2025.
+        mc_split_half = 0  # use events with (run+lumi+evt)%2 == 0
+
+    if not control_plots and not args.bdt_roc and "qcd" in samples_year:
         samples_year.remove("qcd")
     cutflow = pd.DataFrame(index=samples_year)
     cutflow_dict = {}
@@ -526,11 +537,15 @@ def load_process_run3_samples(
     for key in samples_year:
         logger.info(f"Load samples {key}")
 
-        samples_to_process = {year: {key: samples_run3[year][key]}}
+        source_year = year
+        if mc_fallback_year is not None and key != hh_vars.data_key:
+            source_year = mc_fallback_year
+
+        samples_to_process = {source_year: {key: samples_run3[source_year][key]}}
 
         events_dict = load_run3_samples(
             f"{args.data_dir}/{args.tag}",
-            year,
+            source_year,
             samples_to_process,
             reorder_txbb=True,
             load_systematics=True,
@@ -539,6 +554,39 @@ def load_process_run3_samples(
             mass_str=mreg_strings[args.txbb],
             bdt_version=args.bdt_model,
         )[key]
+
+        # --- 2024 MC split: use half for 2024, half for 2025 (deterministic) ---
+        if mc_split_half is not None and key != hh_vars.data_key:
+            run_ = events_dict["run"].to_numpy().squeeze()
+            lumi_ = events_dict["luminosityBlock"].to_numpy().squeeze()
+            evt_ = events_dict["event"].to_numpy().squeeze()
+            # Avoid overflow: (a+b+c)%2 = (a%2 + b%2 + c%2)%2
+            mask = ((run_ % 2) + (lumi_ % 2) + (evt_ % 2)) % 2 == mc_split_half
+            events_dict = events_dict.loc[mask].copy()
+
+            # LUMI SCALING (2024): we keep half the events; scale weights by 2 so that
+            # the total weighted yield matches full 2024 MC (i.e. full 2024 lumi).
+            if year == "2024":
+                weight_cols = [
+                    col
+                    for col in events_dict.columns.get_level_values(0).unique()
+                    if col in {"weight", "finalWeight", "scale_weights", "pdf_weights"}
+                    or (col.startswith("weight_") and "noxsec" not in col and "nonorm" not in col)
+                ]
+                for col in weight_cols:
+                    events_dict[col] = events_dict[col] * 2.0
+
+        # --- LUMI SCALING (2025): MC from fallback year (2024) is norm'd to 2024 lumi;
+        # scale weights by LUMI_2025/LUMI_2024 so yields match 2025 lumi. ---
+        if mc_fallback_year is not None and key != hh_vars.data_key:
+            weight_cols = []
+            for col in events_dict.columns.get_level_values(0).unique():
+                if col in {"weight", "finalWeight", "scale_weights", "pdf_weights"} or (
+                    col.startswith("weight_") and ("noxsec" not in col and "nonorm" not in col)
+                ):
+                    weight_cols.append(col)
+            for col in weight_cols:
+                events_dict[col] = events_dict[col] * mc_lumi_scale
 
         # inference and assign score
         jshifts = [""]

--- a/src/HH4b/postprocessing/corrections.py
+++ b/src/HH4b/postprocessing/corrections.py
@@ -42,7 +42,7 @@ def _load_txbb_sfs(
         year_ = "2022"
     elif "2023" in year:
         year_ = "2023"
-    elif "2024" in year:
+    elif "2024" in year or "2025" in year:
         print(f"WARNING: Using 2023 txbb correction for {year}")
         year_ = "2023"
     else:
@@ -116,7 +116,7 @@ def _load_ttbar_sfs(year: str, corr: str, txbb_version: str):
         year_ = "2022"
     elif "2023" in year:
         year_ = "2023"
-    elif "2024" in year:
+    elif "2024" in year or "2025" in year:
         print(f"WARNING: Using 2023 ttbar correction for {year}")
         year_ = "2023"
     return correctionlib.CorrectionSet.from_file(
@@ -162,13 +162,20 @@ def _get_json_fname(year: str, label: str, region: str):
 
 
 def _load_trig_effs(year: str, label: str, region: str):
-    fname = _get_json_fname(year, label, region)
+    year_ = year
+    if "2024" in year or "2025" in year:
+        print(f"WARNING: Using 2023 trigger correction for {year}")
+        year_ = "2023"
+    fname = _get_json_fname(year_, label, region)
     return correctionlib.CorrectionSet.from_file(fname)
 
 
 def _get_bins(year: str, label: str, region: str) -> dict[str, list[float]]:
     """Extract bins from json file"""
-    fname = _get_json_fname(year, label, region)
+    year_ = year
+    if "2024" in year or "2025" in year:
+        year_ = "2023"
+    fname = _get_json_fname(year_, label, region)
     with Path(fname).open() as f:
         json_dict = json.load(f)
     sample_dict = json_dict["corrections"][0]["data"]["content"][0]["value"]
@@ -206,14 +213,18 @@ def trigger_SF(year: str, events_dict: dict[str, pd.DataFrame], txbb_str: str, r
     else:
         raise RuntimeError(f"txbb_str {txbb_str} not supported for trigger SF.")
 
+    year_ = year
+    if "2024" in year or "2025" in year:
+        year_ = "2023"
+
     # load trigger efficiencies
     triggereff_ptmsd = _load_trig_effs(year, "ptmsd", region)
     triggereff_btag = _load_trig_effs(year, txbb_str, region)
 
-    eff_data = triggereff_ptmsd[f"fatjet_triggereffdata_{year}_ptmsd"]
-    eff_mc = triggereff_ptmsd[f"fatjet_triggereffmc_{year}_ptmsd"]
-    eff_data_btag = triggereff_btag[f"fatjet_triggereffdata_{year}_{txbb_str}"]
-    eff_mc_btag = triggereff_btag[f"fatjet_triggereffmc_{year}_{txbb_str}"]
+    eff_data = triggereff_ptmsd[f"fatjet_triggereffdata_{year_}_ptmsd"]
+    eff_mc = triggereff_ptmsd[f"fatjet_triggereffmc_{year_}_ptmsd"]
+    eff_data_btag = triggereff_btag[f"fatjet_triggereffdata_{year_}_{txbb_str}"]
+    eff_mc_btag = triggereff_btag[f"fatjet_triggereffmc_{year_}_{txbb_str}"]
 
     # extract bins
     ptmsd_bins_dict = _get_bins(year, "ptmsd", region)

--- a/src/HH4b/postprocessing/postprocessing.py
+++ b/src/HH4b/postprocessing/postprocessing.py
@@ -69,8 +69,13 @@ HLTs = {
     ],
     "2024": [
         "AK8PFJet230_SoftDropMass40_PNetBB0p06",
-        "AK8PFJet400_SoftDropMass40",
-        "AK8PFJet425_SoftDropMass40",
+        "AK8PFJet400_SoftDropMass30",
+        "AK8PFJet425_SoftDropMass30",
+    ],
+    "2025": [
+        "AK8PFJet230_SoftDropMass40_PNetBB0p06",
+        "AK8PFJet400_SoftDropMass30",
+        "AK8PFJet425_SoftDropMass30",
     ],
 }
 

--- a/src/HH4b/utils.py
+++ b/src/HH4b/utils.py
@@ -214,6 +214,29 @@ def format_columns(columns: list):
     return ret_columns
 
 
+def _resolve_xsec_key(sample: str, xsecs_dict: dict) -> str:
+    if sample in xsecs_dict:
+        return sample
+
+    aliases = [
+        sample.replace("QCD-4Jets_HT-", "QCD_HT-"),
+        sample.replace("TTHto2B_M-125", "ttHto2B_M-125"),
+    ]
+    for alias in aliases:
+        if alias in xsecs_dict:
+            return alias
+
+    # Last fallback: case-insensitive exact key match.
+    lowered = sample.lower()
+    ci_matches = [k for k in xsecs_dict if k.lower() == lowered]
+    if len(ci_matches) == 1:
+        return ci_matches[0]
+
+    raise KeyError(
+        f"No xsec entry for sample '{sample}' (tried aliases {aliases}, ci_matches={ci_matches})"
+    )
+
+
 def _normalize_weights(
     events: pd.DataFrame,
     year: str,
@@ -231,8 +254,9 @@ def _normalize_weights(
 
     # check weights are scaled
     if "weight_noxsec" in events and np.all(events["weight"] == events["weight_noxsec"]):
+        xsec_key = _resolve_xsec_key(sample, xsecs)
         warnings.warn(f"{sample} has not been scaled by its xsec and lumi!", stacklevel=0)
-        events["weight"] = events["weight"].to_numpy() * xsecs[sample] * LUMI[year]
+        events["weight"] = events["weight"].to_numpy() * xsecs[xsec_key] * LUMI[year]
         warnings.warn(
             f"Temporarily scaling {sample} by its xsec and lumi - remember to remove after fixing in the processor!",
             stacklevel=0,

--- a/tests/test_hhvars_contracts.py
+++ b/tests/test_hhvars_contracts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from HH4b import hh_vars
+
+
+def test_run3_years_are_present_in_samples_map():
+    for year in hh_vars.years:
+        assert year in hh_vars.samples_run3
+
+
+def test_qcd_selector_supports_both_naming_conventions():
+    qcd_selectors = set(hh_vars.common_samples_bg["qcd"])
+    assert "QCD-4Jets_HT" in qcd_selectors
+    assert "QCD_HT-" in qcd_selectors
+
+
+def test_required_background_selectors_are_non_empty():
+    required = ["qcd", "ttbar", "zz", "nozzdiboson", "vjets"]
+    for key in required:
+        assert key in hh_vars.common_samples_bg
+        assert len(hh_vars.common_samples_bg[key]) > 0
+
+
+def test_diboson_selector_contract():
+    assert hh_vars.common_samples_bg["zz"] == ["ZZ?"]
+    assert set(hh_vars.common_samples_bg["nozzdiboson"]) == {"WW?", "WZ?"}
+
+
+def test_lumi_has_combined_2025_key():
+    assert "2025" in hh_vars.LUMI
+    assert hh_vars.LUMI["2025"] > 0
+
+
+def test_2024_and_2025_haves_data_key():
+    assert "data" in hh_vars.samples_run3["2024"]
+    assert "data" in hh_vars.samples_run3["2025"]
+    assert len(hh_vars.samples_run3["2024"]["data"]) > 0
+    assert len(hh_vars.samples_run3["2025"]["data"]) > 0

--- a/tests/test_xsec_resolution.py
+++ b/tests/test_xsec_resolution.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("hist")
+
+from HH4b.utils import _resolve_xsec_key
+
+
+def test_resolve_xsec_key_exact_match():
+    xsecs = {"QCD_HT-1000to1200": 1.0}
+    assert _resolve_xsec_key("QCD_HT-1000to1200", xsecs) == "QCD_HT-1000to1200"
+
+
+def test_resolve_xsec_key_qcd_alias():
+    xsecs = {"QCD_HT-1000to1200": 1.0}
+    assert _resolve_xsec_key("QCD-4Jets_HT-1000to1200", xsecs) == "QCD_HT-1000to1200"
+
+
+def test_resolve_xsec_key_tth_alias():
+    xsecs = {"ttHto2B_M-125": 1.0}
+    assert _resolve_xsec_key("TTHto2B_M-125", xsecs) == "ttHto2B_M-125"
+
+
+def test_resolve_xsec_key_case_insensitive_unique():
+    xsecs = {"vbfhto2b_m-125_dipolerecoilon": 1.0}
+    assert (
+        _resolve_xsec_key("VBFHto2B_M-125_dipoleRecoilOn", xsecs) == "vbfhto2b_m-125_dipolerecoilon"
+    )
+
+
+def test_resolve_xsec_key_raises_for_ambiguous_case_insensitive_match():
+    xsecs = {
+        "sampleA": 1.0,
+        "SAMPLEA": 2.0,
+    }
+    with pytest.raises(KeyError, match="No xsec entry"):
+        _resolve_xsec_key("SampleA", xsecs)


### PR DESCRIPTION
Adds LUMI["2025"]/LUMI["2022-2025"], dual QCD naming across eras with xsec key alias resolution, exact-match diboson selectors (ZZ?/WW?/WZ?), the 2024 HLT SoftDropMass30 fix + 2025 HLTs, 2023-based SF/trigger fallbacks for 2024/2025, and the deterministic 2024-MC 50/50 split (even half → 2024 ×2, odd half → 2025 scaled to 2025 lumi). CreateDatacard gains --year 2022-2025 with per-era lumi nuisances; PlotFits ylims scaled up. Contract tests included.