### PR TITLE
Add GloParT-v3 tagger support 

### DIFF
--- a/src/HH4b/boosted/TrainBDT.py
+++ b/src/HH4b/boosted/TrainBDT.py
@@ -59,16 +59,19 @@ txbb_preselection = {
     "bbFatJetPNetTXbb": 0.3,
     "bbFatJetPNetTXbbLegacy": 0.8,
     "bbFatJetParTTXbb": 0.3,
+    "bbFatJetParT3TXbb": 0.3,
 }
 msd1_preselection = {
     "bbFatJetPNetTXbb": 40,
     "bbFatJetPNetTXbbLegacy": 40,
     "bbFatJetParTTXbb": 40,
+    "bbFatJetParT3TXbb": 40,
 }
 msd2_preselection = {
     "bbFatJetPNetTXbb": 30,
     "bbFatJetPNetTXbbLegacy": 0,
     "bbFatJetParTTXbb": 30,
+    "bbFatJetParT3TXbb": 30,
 }
 
 control_plot_vars = [
@@ -1349,7 +1352,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--txbb",
-        choices=["pnet-v12", "pnet-legacy", "glopart-v2"],
+        choices=["pnet-v12", "pnet-legacy", "glopart-v2", "glopart-v3"],
         help="txbb version to be used for cuts and txbb performance comparison",
         required=True,
     )
@@ -1392,6 +1395,7 @@ if __name__ == "__main__":
         "pnet-v12": "bbFatJetPNetTXbb",
         "pnet-legacy": "bbFatJetPNetTXbbLegacy",
         "glopart-v2": "bbFatJetParTTXbb",
+        "glopart-v3": "bbFatJetParT3TXbb",
     }[args.txbb]
     args.mass_str = args.mass
 

--- a/src/HH4b/boosted/bdt_trainings_run3/v13_glopartv3.py
+++ b/src/HH4b/boosted/bdt_trainings_run3/v13_glopartv3.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import vector
+
+from HH4b.utils import discretize_var
+
+"""
+Same BDT inputs as v13_glopartv2.py, but reading the GloParT-v3 (ParT3)
+branches (bbFatJetParT3TXbb / bbFatJetParT3massX2p) for use with
+txbb_version='glopart-v3' ntuples. Select with --bdt-config v13_glopartv3.
+
+"""
+
+
+def bdt_dataframe(events, key_map=lambda x: x):
+    """
+    Make dataframe with BDT inputs
+    NOTE: this function should be saved along with the model for inference usage
+    """
+
+    h1 = vector.array(
+        {
+            "pt": events[key_map("bbFatJetPt")].to_numpy()[:, 0],
+            "phi": events[key_map("bbFatJetPhi")].to_numpy()[:, 0],
+            "eta": events[key_map("bbFatJetEta")].to_numpy()[:, 0],
+            "M": events[key_map("bbFatJetParT3massX2p")].to_numpy()[:, 0],
+        }
+    )
+    h2 = vector.array(
+        {
+            "pt": events[key_map("bbFatJetPt")].to_numpy()[:, 1],
+            "phi": events[key_map("bbFatJetPhi")].to_numpy()[:, 1],
+            "eta": events[key_map("bbFatJetEta")].to_numpy()[:, 1],
+            "M": events[key_map("bbFatJetParT3massX2p")].to_numpy()[:, 1],
+        }
+    )
+    hh = h1 + h2
+
+    vbf1 = vector.array(
+        {
+            "pt": events[key_map("VBFJetPt")].to_numpy()[:, 0],
+            "phi": events[key_map("VBFJetPhi")].to_numpy()[:, 0],
+            "eta": events[key_map("VBFJetEta")].to_numpy()[:, 0],
+            "M": events[key_map("VBFJetMass")].to_numpy()[:, 0],
+        }
+    )
+
+    vbf2 = vector.array(
+        {
+            "pt": events[key_map("VBFJetPt")].to_numpy()[:, 1],
+            "phi": events[key_map("VBFJetPhi")].to_numpy()[:, 1],
+            "eta": events[key_map("VBFJetEta")].to_numpy()[:, 1],
+            "M": events[key_map("VBFJetMass")].to_numpy()[:, 1],
+        }
+    )
+
+    jj = vbf1 + vbf2
+
+    # AK4JetAway
+    ak4away1 = vector.array(
+        {
+            "pt": events[key_map("AK4JetAwayPt")].to_numpy()[:, 0],
+            "phi": events[key_map("AK4JetAwayPhi")].to_numpy()[:, 0],
+            "eta": events[key_map("AK4JetAwayEta")].to_numpy()[:, 0],
+            "M": events[key_map("AK4JetAwayMass")].to_numpy()[:, 0],
+        }
+    )
+
+    ak4away2 = vector.array(
+        {
+            "pt": events[key_map("AK4JetAwayPt")].to_numpy()[:, 1],
+            "phi": events[key_map("AK4JetAwayPhi")].to_numpy()[:, 1],
+            "eta": events[key_map("AK4JetAwayEta")].to_numpy()[:, 1],
+            "M": events[key_map("AK4JetAwayMass")].to_numpy()[:, 1],
+        }
+    )
+
+    h1ak4away1 = h1 + ak4away1
+    h2ak4away2 = h2 + ak4away2
+
+    df_events = pd.DataFrame(
+        {
+            # dihiggs system
+            key_map("HHPt"): hh.pt,
+            key_map("HHeta"): hh.eta,
+            key_map("HHmass"): hh.mass,
+            # met in the event
+            key_map("MET"): events.MET_pt[0],
+            # fatjet tau32
+            key_map("H1T32"): events[key_map("bbFatJetTau3OverTau2")].to_numpy()[:, 0],
+            key_map("H2T32"): events[key_map("bbFatJetTau3OverTau2")].to_numpy()[:, 1],
+            # fatjet mass
+            key_map("H1Mass"): events[key_map("bbFatJetParT3massX2p")].to_numpy()[:, 0],
+            # fatjet kinematics
+            key_map("H1Pt"): h1.pt,
+            key_map("H2Pt"): h2.pt,
+            key_map("H1eta"): h1.eta,
+            # xbb
+            key_map("H1Xbb"): discretize_var(
+                events[key_map("bbFatJetParT3TXbb")].to_numpy()[:, 0],
+                bins=[0, 0.8, 0.9, 0.94, 0.97, 0.99, 1],
+            ),
+            # ratios
+            key_map("H1Pt_HHmass"): h1.pt / hh.mass,
+            key_map("H2Pt_HHmass"): h2.pt / hh.mass,
+            key_map("H1Pt/H2Pt"): h1.pt / h2.pt,
+            # vbf mjj and eta_jj
+            key_map("VBFjjMass"): np.array(jj.mass),
+            key_map("VBFjjDeltaEta"): np.array(np.abs(vbf1.eta - vbf2.eta)),
+            # AK4JetAway
+            key_map("H1AK4JetAway1dR"): h1.deltaR(ak4away1),
+            key_map("H2AK4JetAway2dR"): h2.deltaR(ak4away2),
+            key_map("H1AK4JetAway1mass"): h1ak4away1.mass,
+            key_map("H2AK4JetAway2mass"): h2ak4away2.mass,
+        }
+    )
+
+    return df_events

--- a/src/HH4b/hh_vars.py
+++ b/src/HH4b/hh_vars.py
@@ -448,6 +448,7 @@ jmsr_res["bbFatJetParTmassVis"]["nozzdiboson"] = 10.7 * 80.0 / 125.0
 ttbarsfs_decorr_txbb_bins = {}
 ttbarsfs_decorr_txbb_bins["pnet-legacy"] = [0, 0.8, 0.94, 0.99, 1]
 ttbarsfs_decorr_txbb_bins["glopart-v2"] = [0, 0.31, 0.7, 0.8, 0.87, 0.92, 0.96, 1]
+ttbarsfs_decorr_txbb_bins["glopart-v3"] = ttbarsfs_decorr_txbb_bins["glopart-v2"]
 ttbarsfs_decorr_ggfbdt_bins = {}
 ttbarsfs_decorr_ggfbdt_bins["24May31_lr_0p02_md_8_AK4Away"] = [0.03, 0.3, 0.5, 0.7, 0.93, 1.0]
 ttbarsfs_decorr_ggfbdt_bins["24Nov7_v5_glopartv2_rawmass"] = [0.03, 0.6375, 0.9075, 1.0]
@@ -476,6 +477,7 @@ txbbsfs_decorr_txbb_wps["glopart-v2"] = OrderedDict(
         ("WP1", [0.99, 1]),
     ]
 )
+txbbsfs_decorr_txbb_wps["glopart-v3"] = txbbsfs_decorr_txbb_wps["glopart-v2"]
 
 txbbsfs_decorr_pt_bins = {}
 txbbsfs_decorr_pt_bins["pnet-legacy"] = OrderedDict(
@@ -496,15 +498,20 @@ txbbsfs_decorr_pt_bins["glopart-v2"] = OrderedDict(
         ("WP1", [250, 450, 100000]),
     ]
 )
+txbbsfs_decorr_pt_bins["glopart-v3"] = txbbsfs_decorr_pt_bins["glopart-v2"]
 
 txbb_strings = {
     "pnet-legacy": "bbFatJetPNetTXbbLegacy",
     "pnet-v12": "bbFatJetPNetTXbb",
     "glopart-v2": "bbFatJetParTTXbb",
+    # ParT v3 ntuples (new): use ParT3 TXbb branch
+    "glopart-v3": "bbFatJetParT3TXbb",
 }
 
 mreg_strings = {
     "pnet-legacy": "bbFatJetPNetMassLegacy",
     "pnet-v12": "bbFatJetPNetMass",
     "glopart-v2": "bbFatJetParTmassVis",
+    # ParT v3 ntuples: use X2p ParT3 mass
+    "glopart-v3": "bbFatJetParT3massX2p",
 }

--- a/src/HH4b/postprocessing/CreateDatacard.py
+++ b/src/HH4b/postprocessing/CreateDatacard.py
@@ -122,7 +122,7 @@ parser.add_argument(
     "--txbb",
     type=str,
     default="",
-    choices=["pnet-legacy", "pnet-v12", "glopart-v2"],
+    choices=["pnet-legacy", "pnet-v12", "glopart-v2", "glopart-v3"],
     help="version of TXbb tagger/mass regression to use",
 )
 parser.add_argument(

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -978,7 +978,7 @@ def load_process_run3_samples(
 
         if args.txbb == "pnet-legacy":
             txbb_presel = 0.8
-        elif args.txbb in ["glopart-v2", "pnet-v12"]:
+        elif args.txbb in ["glopart-v2", "glopart-v3", "pnet-v12"]:
             txbb_presel = 0.3
 
         for jshift in jshifts:
@@ -1484,6 +1484,10 @@ def make_control_plots(events_dict, plot_dir, year, txbb_version):
         txbb_label = "PNet 103X"
     elif txbb_version == "glopart-v2":
         txbb_label = "GloParTv2"
+    elif txbb_version == "glopart-v3":
+        txbb_label = "GloParTv3"
+    else:
+        txbb_label = txbb_version
 
     control_plot_vars = [
         ShapeVar(var="bdt_score", label=r"BDT score ggF", bins=[30, 0, 1], blind_window=[0.8, 1.0]),
@@ -1780,6 +1784,10 @@ def postprocess_run3(args):
     elif args.txbb == "pnet-v12":
         fom_window_by_mass["H2PNetMass"] = [120, 150]
         blind_window_by_mass["H2PNetMass"] = [120, 150]
+    # for glopart-v3, reuse the glopart-v2 windows
+    elif args.txbb == "glopart-v3":
+        fom_window_by_mass["H2PNetMass"] = [110, 155]
+        blind_window_by_mass["H2PNetMass"] = [110, 140]
 
     mass_window = np.array(fom_window_by_mass[args.mass])
 
@@ -2220,7 +2228,7 @@ if __name__ == "__main__":
         "--txbb",
         type=str,
         default="glopart-v2",
-        choices=["pnet-legacy", "pnet-v12", "glopart-v2"],
+        choices=["pnet-legacy", "pnet-v12", "glopart-v2", "glopart-v3"],
         help="version of TXbb tagger/mass regression to use",
     )
     parser.add_argument(

--- a/src/HH4b/postprocessing/PostProcessTT.py
+++ b/src/HH4b/postprocessing/PostProcessTT.py
@@ -671,7 +671,7 @@ if __name__ == "__main__":
         "--txbb",
         type=str,
         default="",
-        choices=["pnet-legacy", "pnet-v12", "glopart-v2"],
+        choices=["pnet-legacy", "pnet-v12", "glopart-v2", "glopart-v3"],
         help="version of TXbb tagger/mass regression to use",
     )
     run_utils.add_bool_arg(parser, "control-plots", default=False, help="make control plots")

--- a/src/HH4b/postprocessing/corrections.py
+++ b/src/HH4b/postprocessing/corrections.py
@@ -164,8 +164,8 @@ def _get_json_fname(year: str, label: str, region: str):
 def _load_trig_effs(year: str, label: str, region: str):
     year_ = year
     if "2024" in year or "2025" in year:
-        print(f"WARNING: Using 2023 trigger correction for {year}")
-        year_ = "2023"
+        print(f"WARNING: Using 2023BPix trigger efficiencies for {year}")
+        year_ = "2023BPix"
     fname = _get_json_fname(year_, label, region)
     return correctionlib.CorrectionSet.from_file(fname)
 
@@ -174,7 +174,7 @@ def _get_bins(year: str, label: str, region: str) -> dict[str, list[float]]:
     """Extract bins from json file"""
     year_ = year
     if "2024" in year or "2025" in year:
-        year_ = "2023"
+        year_ = "2023BPix"
     fname = _get_json_fname(year_, label, region)
     with Path(fname).open() as f:
         json_dict = json.load(f)
@@ -218,7 +218,7 @@ def trigger_SF(year: str, events_dict: dict[str, pd.DataFrame], txbb_str: str, r
 
     year_ = year
     if "2024" in year or "2025" in year:
-        year_ = "2023"
+        year_ = "2023BPix"
 
     # load trigger efficiencies
     triggereff_ptmsd = _load_trig_effs(year, "ptmsd", region)

--- a/src/HH4b/postprocessing/corrections.py
+++ b/src/HH4b/postprocessing/corrections.py
@@ -204,10 +204,13 @@ def trigger_SF(year: str, events_dict: dict[str, pd.DataFrame], txbb_str: str, r
     """
     Evaluate trigger Scale Factors
     """
-    if "legacy" in txbb_str.lower():
+    if txbb_str == "bbFatJetPNetTXbbLegacy":
         txbb_str = "txbbPNetLegacy"
         txbb = "bbFatJetPNetTXbbLegacy"
-    elif "part" in txbb_str.lower():
+    elif txbb_str == "bbFatJetParT3TXbb":
+        txbb_str = "txbbGloParT"
+        txbb = "bbFatJetParT3TXbb"
+    elif txbb_str == "bbFatJetParTTXbb":
         txbb_str = "txbbGloParT"
         txbb = "bbFatJetParTTXbb"
     else:

--- a/src/HH4b/postprocessing/postprocessing.py
+++ b/src/HH4b/postprocessing/postprocessing.py
@@ -131,6 +131,15 @@ columns_to_load = {
         ("bbFatJetParTPQCD2HF", 2),
         ("bbFatJetrawFactor", 2),
     ],
+    # ParT v3 ntuples (used with txbb_version='glopart-v3'):
+    # use ParT3 TXbb and X2p mass branch
+    "glopart-v3": columns_to_load_default
+    + [
+        ("bbFatJetParT3TXbb", 2),
+        ("bbFatJetParT3PXbb", 2),
+        ("bbFatJetParT3massX2p", 2),
+        ("bbFatJetrawFactor", 2),
+    ],
 }
 
 filters_to_apply = {
@@ -155,6 +164,13 @@ filters_to_apply = {
         ],
     ],
     "glopart-v2": [
+        [
+            ("('bbFatJetPt', '0')", ">=", 250),
+            ("('bbFatJetPt', '1')", ">=", 250),
+        ],
+    ],
+    # ParT v3: same pT preselection as v2
+    "glopart-v3": [
         [
             ("('bbFatJetPt', '0')", ">=", 250),
             ("('bbFatJetPt', '1')", ">=", 250),
@@ -429,7 +445,8 @@ def load_run3_samples(
         "pnet-v12",
         "pnet-legacy",
         "glopart-v2",
-    ], "txbb_version parameter must be pnet-v12, pnet-legacy, glopart-v2"
+        "glopart-v3",
+    ], "txbb_version parameter must be pnet-v12, pnet-legacy, glopart-v2, glopart-v3"
 
     txbb_str = txbb_strings[txbb_version]
     filters = filters_to_apply[txbb_version]
@@ -437,6 +454,14 @@ def load_run3_samples(
     # Re-instantiate lists to avoid mutating global variables
     load_columns = list(columns_to_load[txbb_version])
     load_columns_systematics = list(load_columns_syst)
+    if txbb_version == "glopart-v3":
+        load_columns_systematics = [
+            (
+                col.replace("bbFatJetParTmassVis", "bbFatJetParT3massX2p"),
+                ncols,
+            )
+            for col, ncols in load_columns_systematics
+        ]
 
     if load_bdt_scores:
         load_columns += [

--- a/tests/test_postprocessing_load_run3_samples.py
+++ b/tests/test_postprocessing_load_run3_samples.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("hist")
+pytest.importorskip("pandas")
+pytest.importorskip("sklearn")
+
+from HH4b.postprocessing import postprocessing as pp
+
+
+def _base_samples_run3_for_year(year: str) -> dict[str, dict[str, list[str]]]:
+    return {
+        year: {
+            "data": [f"JetMET_Run{year}X"],
+            "qcd": ["QCD_HT-"],
+            "ttbar": ["TTto4Q"],
+            "hh4b": ["GluGlutoHHto4B_kl-1p00_kt-1p00_c2-0p00"],
+            "vbfhh4b": ["VBFHHto4B_CV_1_C2V_1_C3_1"],
+        }
+    }
+
+
+def test_load_run3_samples_partitions_and_attaches_year_hlts(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_load_samples(_input_dir, samples, _year, **kwargs):
+        calls.append({"samples": list(samples.keys()), "columns": kwargs.get("columns", [])})
+        return {label: {"weight": [1.0]} for label in samples}
+
+    monkeypatch.setattr(pp.utils, "load_samples", fake_load_samples)
+
+    samples_run3 = _base_samples_run3_for_year("2024")
+    events = pp.load_run3_samples(
+        input_dir="/tmp/does_not_matter",
+        year="2024",
+        samples_run3=samples_run3,
+        reorder_txbb=False,
+        load_systematics=False,
+        txbb_version="glopart-v2",
+        scale_and_smear=False,
+        mass_str="bbFatJetParTmassVis",
+        bdt_version="unit-test-bdt",
+    )
+
+    assert set(events) == {"data", "qcd", "ttbar", "hh4b", "vbfhh4b"}
+    assert len(calls) == 5
+    for call in calls:
+        for hlt in pp.HLTs["2024"]:
+            assert any(hlt in col for col in call["columns"])
+
+
+def test_load_run3_samples_glopart_v3_rewrites_systematic_mass_columns(monkeypatch):
+    captured_columns: list[list[str]] = []
+
+    def fake_load_samples(_input_dir, samples, _year, **kwargs):
+        if samples:
+            captured_columns.append(kwargs.get("columns", []))
+        return {label: {"weight": [1.0]} for label in samples}
+
+    monkeypatch.setattr(pp.utils, "load_samples", fake_load_samples)
+
+    samples_run3 = _base_samples_run3_for_year("2024")
+    pp.load_run3_samples(
+        input_dir="/tmp/does_not_matter",
+        year="2024",
+        samples_run3=samples_run3,
+        reorder_txbb=False,
+        load_systematics=True,
+        txbb_version="glopart-v3",
+        scale_and_smear=False,
+        mass_str="bbFatJetParT3massX2p",
+        bdt_version="unit-test-bdt",
+    )
+
+    all_columns = [col for call_columns in captured_columns for col in call_columns]
+    assert any("bbFatJetParT3massX2p_JMS_up" in col for col in all_columns)
+    assert not any("bbFatJetParTmassVis_JMS_up" in col for col in all_columns)


### PR DESCRIPTION
ParT3 branches end-to-end: column/filter configs, JMS/JMR systematic-column remap, exact-match trigger-SF branch selection, TXbb preselection/labels/windows, argparse choices everywhere, SF bins/WPs aliased from glopart-v2. 

new bdt config v13_glopartv3.py added