### PR TITLE
Update postprocessing README and .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,22 @@ src/HH4b/processors/skimmer_plots
 
 running_jobs.txt
 
+# CMSSW (build dir - huge)
+CMSSW_11_3_4/
+src/CMSSW_11_3_4/
+
+# rhalphalib (if installed as package)
+rhalphalib/
+
+# PID files
+*.pid
+run.pid
+
+# Logs/outputs under src
+src/HH4b/postprocessing/*.out
+src/HH4b/boosted/*.out
+queue_master.out
+
 .bashrc
 .condor_config
 .local/

--- a/src/HH4b/combine/binder/FTest.ipynb
+++ b/src/HH4b/combine/binder/FTest.ipynb
@@ -33,9 +33,9 @@
     "\n",
     "MAIN_DIR = Path(HH4b.__file__).parents[2]\n",
     "\n",
-    "passbin = \"passbin3\"\n",
+    "passbin = \"passbin1\"\n",
     "\n",
-    "plot_dir = MAIN_DIR / f\"plots/FTests/run3-bdt-february10-glopartv2-bdtv13/{passbin}\"\n",
+    "plot_dir = MAIN_DIR / f\"plots/FTests/run3-bdt-26Jan15/{passbin}\"\n",
     "plot_dir.mkdir(exist_ok=True, parents=True)"
    ]
   },
@@ -69,7 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "local_cards_dir = MAIN_DIR / \"src/HH4b/cards/f_tests/run3-bdt-february10-glopartv2-bdtv13\"\n",
+    "local_cards_dir = MAIN_DIR / \"cards/f_tests/run3-bdt-26Jan15\"\n",
+    "print(local_cards_dir)\n",
     "\n",
     "test_orders = [0]\n",
     "test_statistics = {}\n",

--- a/src/HH4b/plotting.py
+++ b/src/HH4b/plotting.py
@@ -584,10 +584,9 @@ def ratioHistPlot(
     # re-weight qcd
     kfactor = dict.fromkeys(bg_keys, 1)
     if reweight_qcd and qcd_norm is None:
-        non_qcd_yield = np.sum(
-            sum([hists[sample, :] for sample in bg_keys if sample != "qcd"]).values()
-        )
-        qcd_yield = np.sum(hists["qcd", :].values())
+        non_qcd_hists = [hists[sample, :] for sample in bg_keys if sample != "qcd"]
+        non_qcd_yield = np.sum(sum(non_qcd_hists).values()) if non_qcd_hists else 0.0
+        qcd_yield = np.sum(hists["qcd", :].values()) if "qcd" in hists.axes[0] else 0.0
         data_yield = np.sum(hists[data_key, :].values())
         if qcd_yield > 0:
             kfactor["qcd"] = (data_yield - non_qcd_yield) / qcd_yield

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -618,7 +618,11 @@ def load_process_run3_samples(
             scale_and_smear=args.scale_smear,
             mass_str=mreg_strings[args.txbb],
             bdt_version=args.bdt_model,
-        )[key]
+        )
+        if key not in events_dict:
+            logger.warning(f"Skipping {key}: no events loaded for current selectors")
+            continue
+        events_dict = events_dict[key]
 
         # --- 2024 MC split: use half for 2024, half for 2025 (deterministic) ---
         if mc_split_half is not None and key != hh_vars.data_key:
@@ -1220,7 +1224,7 @@ def load_process_run3_samples(
             ]
         if key != "data":
             columns += ["weight_triggerUp", "weight_triggerDown"] + pileup_ps_weights
-        columns = list(set(columns))
+        columns = list(dict.fromkeys(columns))  # deduplicate while preserving order
 
         if control_plots:
             bdt_events = bdt_events.rename(
@@ -1587,6 +1591,9 @@ def make_control_plots(events_dict, plot_dir, year, txbb_version):
 
     # Find the normalization needed to reweight QCD
     qcd_norm = 1.0
+    available_keys = set(events_dict.keys())
+    control_sig_keys = [k for k in ["hh4b", "vbfhh4b", "vbfhh4b-k2v0"] if k in available_keys]
+    control_bg_keys = [k for k in bg_keys if k in available_keys]
 
     hists = {}
     for i, shape_var in enumerate(control_plot_vars):
@@ -1600,8 +1607,8 @@ def make_control_plots(events_dict, plot_dir, year, txbb_version):
             qcd_norm_tmp = plotting.ratioHistPlot(
                 hists[shape_var.var],
                 year,
-                ["hh4b", "vbfhh4b", "vbfhh4b-k2v0"],
-                bg_keys,
+                control_sig_keys,
+                control_bg_keys,
                 name=f"{plot_dir}/control/{year}/{shape_var.var}",
                 show=False,
                 log=True,
@@ -1646,14 +1653,18 @@ def abcd(
     bg_keys_all,
     sig_keys,
 ):
-    bg_keys = bg_keys_all.copy()
+    available_keys = set(events_dict.keys())
+    bg_keys = [k for k in bg_keys_all if k in available_keys]
     if "qcd" in bg_keys:
         bg_keys.remove("qcd")
+    sig_keys = [k for k in sig_keys if k in available_keys]
 
     dicts = {"data": [], **{key: [] for key in bg_keys}}
 
     s = 0
     for key in sig_keys + ["data"] + bg_keys:
+        if key not in events_dict:
+            continue
         events = events_dict[key]
         cut = get_cut(events, txbb_cut, bdt_cut)
 
@@ -1684,7 +1695,7 @@ def abcd(
     # A = B * C / D
     bqcd = dmt[1] * dmt[2] / dmt[3]
 
-    background = bqcd + bg_tots[0] if len(bg_keys) else bqcd
+    background = bqcd + bg_tots[0] if bg_keys else bqcd
     return s, background, dmt
 
 

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import logging.config
 import pprint
+import sys
 from collections import OrderedDict
 from pathlib import Path
 from typing import Callable
@@ -172,6 +173,70 @@ def add_bdt_scores(
             if bdt_disc
             else preds[:, 1] + preds[:, 2]
         )
+
+
+def _build_and_score_bdt_events(
+    events: pd.DataFrame,
+    make_bdt_dataframe,
+    key_map: Callable,
+    rerun_inference: bool,
+    bdt_model,
+    chunk_size: int,
+    weight_ttbar: float,
+    bdt_disc: bool,
+    jshift: str,
+) -> pd.DataFrame:
+    """Build BDT inputs in row chunks to reduce peak memory before inference."""
+    n_events = len(events)
+    if chunk_size <= 0 or n_events <= chunk_size:
+        chunks = [(0, n_events)]
+    else:
+        chunks = [
+            (start, min(start + chunk_size, n_events)) for start in range(0, n_events, chunk_size)
+        ]
+
+    built_chunks: list[pd.DataFrame] = []
+    jlabel = f"_{jshift}" if jshift != "" else ""
+
+    total_chunks = len(chunks)
+    for i, (start, end) in enumerate(chunks, start=1):
+        progress_msg = f"BDT chunk {i}/{total_chunks} for jshift {jshift or 'nominal'}"
+        if sys.stderr.isatty():
+            print(
+                f"\r{progress_msg}",
+                end="" if i < total_chunks else "\n",
+                file=sys.stderr,
+                flush=True,
+            )
+        elif _should_log_chunk_progress(i, total_chunks):
+            logger.info(progress_msg)
+        events_chunk = events.iloc[start:end]
+        bdt_chunk = make_bdt_dataframe.bdt_dataframe(events_chunk, key_map)
+        if rerun_inference:
+            preds = bdt_model.predict_proba(bdt_chunk)
+            add_bdt_scores(
+                bdt_chunk,
+                preds,
+                jshift,
+                weight_ttbar=weight_ttbar,
+                bdt_disc=bdt_disc,
+            )
+        else:
+            bdt_chunk[f"bdt_score{jlabel}"] = events_chunk[f"bdt_score{jlabel}"]
+            bdt_chunk[f"bdt_score_vbf{jlabel}"] = events_chunk[f"bdt_score_vbf{jlabel}"]
+        built_chunks.append(bdt_chunk)
+
+    if len(built_chunks) == 1:
+        return built_chunks[0]
+    return pd.concat(built_chunks, ignore_index=True)
+
+
+def _should_log_chunk_progress(chunk_num: int, total_chunks: int) -> bool:
+    """Limit progress logs for redirected output files."""
+    if total_chunks <= 10:
+        return True
+    interval = max(1, total_chunks // 10)
+    return chunk_num == 1 or chunk_num == total_chunks or chunk_num % interval == 0
 
 
 def bdt_roc(events_combined: dict[str, pd.DataFrame], plot_dir: str, txbb_version: str, jshift=""):
@@ -598,29 +663,25 @@ def load_process_run3_samples(
 
         logger.info("Add BDT scores")
         bdt_events = {}
+        chunk_size = args.bdt_inference_chunk_size
         for jshift in jshifts:
-            _jshift = f"_{jshift}" if jshift != "" else ""
-            bdt_events[jshift] = make_bdt_dataframe.bdt_dataframe(
-                events_dict, get_var_mapping(jshift)
-            )
             if rerun_inference:
-                print("Re-run inference")
-                preds = bdt_model.predict_proba(bdt_events[jshift])
-                add_bdt_scores(
-                    bdt_events[jshift],
-                    preds,
-                    jshift,
-                    weight_ttbar=args.weight_ttbar_bdt,
-                    bdt_disc=args.bdt_disc,
-                )
+                logger.info("Re-run inference")
             else:
                 # assert bdt_disc is true
                 if not args.bdt_disc:
                     raise ValueError("only BDT discriminant available from skimmer")
-                bdt_events[jshift][f"bdt_score{_jshift}"] = events_dict[f"bdt_score{_jshift}"]
-                bdt_events[jshift][f"bdt_score_vbf{_jshift}"] = events_dict[
-                    f"bdt_score_vbf{_jshift}"
-                ]
+            bdt_events[jshift] = _build_and_score_bdt_events(
+                events_dict,
+                make_bdt_dataframe,
+                get_var_mapping(jshift),
+                rerun_inference=rerun_inference,
+                bdt_model=bdt_model if rerun_inference else None,
+                chunk_size=chunk_size,
+                weight_ttbar=args.weight_ttbar_bdt,
+                bdt_disc=args.bdt_disc,
+                jshift=jshift,
+            )
 
             # redefine VBF variables
             key_map = get_var_mapping(jshift)
@@ -640,10 +701,12 @@ def load_process_run3_samples(
             bdt_events[jshift].loc[mask_negative_ak4away2, key_map("H2AK4JetAway2dR")] = -1
             bdt_events[jshift].loc[mask_negative_ak4away2, key_map("H2AK4JetAway2mass")] = -1
 
-        bdt_events = pd.concat([bdt_events[jshift] for jshift in jshifts], axis=1)
-
-        # remove duplicates
-        bdt_events = bdt_events.loc[:, ~bdt_events.columns.duplicated()].copy()
+        if len(jshifts) == 1:
+            bdt_events = bdt_events[jshifts[0]]
+        else:
+            bdt_events = pd.concat([bdt_events[jshift] for jshift in jshifts], axis=1)
+            # remove duplicates (shared nominal columns appear in every per-shift DataFrame)
+            bdt_events = bdt_events.loc[:, ~bdt_events.columns.duplicated()].copy()
         nevents = len(bdt_events.index)
 
         # add more variables for control plots
@@ -753,13 +816,11 @@ def load_process_run3_samples(
             events_dict, key, year, args.txbb, trigger_region, nevents
         )
 
-        # creating new dataframe with all variables
-        # repeatedly allocating new memory for pd.DataFrame is expensive
-        # best to use a dict instead
-        temp_df = pd.DataFrame(more_vars, index=bdt_events.index)
-        bdt_events = pd.concat([bdt_events, temp_df], axis=1)
-        # TODO: code below removes duplicates, why are H1Pt and H2Pt duplicated?
-        bdt_events = bdt_events.loc[:, ~bdt_events.columns.duplicated(keep="first")]
+        # Assign more_vars columns directly to avoid creating intermediate DataFrames.
+        # Some columns (e.g. H1Pt, H2Pt) already exist from bdt_dataframe; skip them.
+        for col, vals in more_vars.items():
+            if col not in bdt_events.columns:
+                bdt_events[col] = vals
 
         # TXbbWeight
         txbb_sf_weight = calculate_txbb_weights(
@@ -783,6 +844,9 @@ def load_process_run3_samples(
             logger.info(f"Keep {fraction}% of {key} for year {year}")
             bdt_events = bdt_events[events_to_keep]
             bdt_events["weight"] *= 1 / fraction  # divide by BDT test / train ratio
+
+        # Release the raw parquet DataFrame; all needed data is now in bdt_events.
+        del events_dict
 
         cutflow_dict[key] = OrderedDict([("Skimmer Preselection", np.sum(bdt_events["weight"]))])
 
@@ -852,26 +916,18 @@ def load_process_run3_samples(
                 stat_up = np.ones(nevents)
                 stat_dn = np.ones(nevents)
                 for ijet in get_jets_for_txbb_sf(key):
+                    # Cache array conversions: same columns are used for nominal/up/dn.
+                    txbb_arr = bdt_events[f"H{ijet}TXbb"].to_numpy()
+                    pt_arr = bdt_events[f"H{ijet}Pt"].to_numpy()
+                    pt_range = TXbb_pt_corr_bins[wp][j : j + 2]
                     nominal *= corrections.restrict_SF(
-                        txbb_sf["nominal"],
-                        bdt_events[f"H{ijet}TXbb"].to_numpy(),
-                        bdt_events[f"H{ijet}Pt"].to_numpy(),
-                        TXbb_wps[wp],
-                        TXbb_pt_corr_bins[wp][j : j + 2],
+                        txbb_sf["nominal"], txbb_arr, pt_arr, TXbb_wps[wp], pt_range
                     )
                     stat_up *= corrections.restrict_SF(
-                        txbb_sf["stat_up"],
-                        bdt_events[f"H{ijet}TXbb"].to_numpy(),
-                        bdt_events[f"H{ijet}Pt"].to_numpy(),
-                        TXbb_wps[wp],
-                        TXbb_pt_corr_bins[wp][j : j + 2],
+                        txbb_sf["stat_up"], txbb_arr, pt_arr, TXbb_wps[wp], pt_range
                     )
                     stat_dn *= corrections.restrict_SF(
-                        txbb_sf["stat_dn"],
-                        bdt_events[f"H{ijet}TXbb"].to_numpy(),
-                        bdt_events[f"H{ijet}Pt"].to_numpy(),
-                        TXbb_wps[wp],
-                        TXbb_pt_corr_bins[wp][j : j + 2],
+                        txbb_sf["stat_dn"], txbb_arr, pt_arr, TXbb_wps[wp], pt_range
                     )
                 variation_vars.update(
                     {
@@ -967,8 +1023,9 @@ def load_process_run3_samples(
                     "weight_ttbarSF_tau32Down": bdt_events["weight"] * tau32sf_dn / tau32sf,
                 }
             )
-        temp_df = pd.DataFrame(variation_vars, index=bdt_events.index)
-        bdt_events = pd.concat([bdt_events, temp_df], axis=1)
+        # Assign variation columns directly; all are new so no duplicate guard needed.
+        for col, vals in variation_vars.items():
+            bdt_events[col] = vals
         bdt_events = bdt_events.reset_index(drop=True)
 
         # HLT selection
@@ -991,8 +1048,6 @@ def load_process_run3_samples(
             category = check_get_jec_var("Category", jshift)
             bdt_score = check_get_jec_var("bdt_score", jshift)
 
-            # TODO: code below removes duplicates, why are H1Pt and H2Pt duplicated?
-            bdt_events = bdt_events.loc[:, ~bdt_events.columns.duplicated(keep="first")]
             mask_presel = (
                 (bdt_events[h1msd] >= 40)  # FIXME: replace by jet matched to trigger object
                 & (bdt_events[h1pt] >= args.pt_first)
@@ -2323,6 +2378,12 @@ if __name__ == "__main__":
     )
     run_utils.add_bool_arg(parser, "blind", default=True, help="Blind the analysis")
     run_utils.add_bool_arg(parser, "rerun-inference", default=True, help="Rerun BDT inference")
+    parser.add_argument(
+        "--bdt-inference-chunk-size",
+        type=int,
+        default=0,
+        help="Chunk size for BDT predict_proba to reduce memory; 0 = no chunking (default: 0)",
+    )
     run_utils.add_bool_arg(
         parser, "scale-smear", default=False, help="Rerun scaling and smearing of mass variables"
     )

--- a/src/HH4b/postprocessing/README.md
+++ b/src/HH4b/postprocessing/README.md
@@ -1,78 +1,124 @@
-# Run-3
+# Postprocessing README (Run-3)
 
-- To postprocess: `PostProcess.py`
-- To create datacards: `CreateDatacard.py`
-- To plot: `PlotFits.py`
+This document explains:
 
-### ANv1:
-```/uscms/home/jduarte1/nobackup/HH4b/src/HH4b/postprocessing/templates/Apr18
-```
-made with:
-```
-cd postprocessing
-python3 PostProcess.py --templates-tag Apr18 --tag 24Mar31_v12_signal --mass H2Msd --no-fom-scan --templates --bdt-model v1_msd30_nomulticlass --bdt-config v1_msd30
-python3 postprocessing/CreateDatacard.py --templates-dir postprocessing/templates/Apr18 --year 2022-2023  --model-name run3-bdt-apr18
-```
-Fits:
-```
-cd cards/run3-bdt-apr18
-run_blinded_hh4b.sh --workspace --bfit --limits --dfit --passbin=0
-python3 postprocessing/PlotFits.py --fit-file cards/run3-bdt-apr18/FitShapes.root --plots-dir ../../plots/PostFit/run3-bdt-apr18 --signal-scale 10
-```
+1. how Run-3 templates are generated in this repository, and
+2. how to unit test postprocessing logic without loading large parquet datasets.
 
-### ANv1
-```
-python3 PostProcess.py --templates-tag May2 --tag 24Apr23LegacyLowerThresholds_v12_private_signal --mass H2Msd --no-legacy --bdt-config v1_msd30_txbb  --bdt-model v1_msd30_nomulticlass  --no-fom-scan --templates --txbb-wps 0.92 0.8 --bdt-wps 0.94 0.68 0.03 --years 2022 2022EE 2023 2023BPix
-```
+## 1) How templates are generated
 
-### ANv2
-Apr 22
-```bash
-python PostProcess.py --templates-tag 24Apr21_legacy_bdt_ggf --data-dir /ceph/cms/store/user/rkansal/bbbb/skimmer/ --tag 24Apr19LegacyFixes_v12_private_signal --mass H2PNetMass --bdt-model 24Apr21_legacy_vbf_vars --bdt-config 24Apr21_legacy_vbf_vars --legacy --no-fom-scan-bin1 --no-fom-scan --no-fom-scan-vbf --no-vbf
-```
-Frozen for ANv2
-```bash
-python3 PostProcess.py --templates-tag 24May9v2Msd40 --tag 24Apr23LegacyLowerThresholds_v12_private_signal --mass H2PNetMass --legacy --bdt-config 24Apr21_legacy_vbf_vars  --bdt-model 24Apr21_legacy_vbf_vars --txbb-wps 0.99 0.94 --bdt-wps 0.94 0.68 0.03 --no-bdt-roc --templates --no-fom-scan --no-fom-scan-vbf --years 2022 2022EE 2023 2023BPix --training-years 2022EE --no-vbf
-```
+### Main entry point (current workflow)
 
-### ANv9
-```
-python3 PostProcess.py --templates-tag 24June3NewBDTNewSamplesPtSecond250 --tag 24May24_v12_private_signal --mass H2PNetMass --legacy --bdt-config 24May31_lr_0p02_md_8_AK4Away --bdt-model 24May31_lr_0p02_md_8_AK4Away --txbb-wps 0.975 0.92 --bdt-wps 0.98 0.88 0.03 --vbf-txbb-wp 0.95 --vbf-bdt-wp 0.98 --no-bdt-roc --no-fom-scan --no-fom-scan-bin2 --no-fom-scan-bin1 --data-dir /ceph/cms/store/user/cmantill/bbbb/skimmer/ --method abcd --no-vbf-priority --vbf --no-fom-scan-vbf --templates --pt-second 250
-```
+Template production is driven by `PostProcess.py`.
 
-```
-python3 PostProcess.py --templates-tag 24June10NewBDTNewSamplesPtSecond300 -tag 24May24_v12_private_signal --mass H2PNetMass --legacy --bdt-config 24May31_lr_0p02_md_8_AK4Away --bdt-model 24May31_lr_0p02_md_8_AK4Away --txbb-wps 0.975 0.92 --bdt-wps 0.98 0.88 0.03 --vbf-txbb-wp 0.95 --vbf-bdt-wp 0.98 --no-bdt-roc --no-fom-scan --no-fom-scan-bin2 --no-fom-scan-bin1 --data-dir /ceph/cms/store/user/cmantill/bbbb/skimmer/ --method abcd --no-vbf-priority --vbf --no-fom-scan-vbf --templates --pt-second 300
-```
-
-To scan:
-```bash
-python3 PostProcess.py --templates-tag Apr22 --tag 24Apr23LegacyLowerThresholds_v12_private_signal --mass H2PNetMass --legacy --bdt-config 24Apr21_legacy_vbf_vars --bdt-model 24Apr21_legacy_vbf_vars  --fom-scan --txbb-wps 0.99 0.94 --bdt-wps 0.94 0.68 0.03 --no-control-plots --no-bdt-roc --no-templates --no-fom-scan-vbf --years 2022EE --method sideband
-```
-
-For tt corrections:
-```bash
-python PostProcessTT.py --templates-tag 24May24 --tag 24May25_v12_private_had-tt --data-dir ../../../../data/skimmer/ --mass H2PNetMass --legacy --control-plots --bdt-model 24Apr21_legacy_vbf_vars --bdt-config 24Apr21_legacy_vbf_vars --year 2022 2022EE 2023 2023BPix
-```
-
-# Run-2
-```bash
-python3 PostProcessRun2.py --template-dir 20210712_regression --tag 20210712_regression --years 2016,2017,2018
-python3 CreateDatacardRun2.py --templates-dir templates/20210712_regression --year all --model-name run2-bdt-20210712 --bin-name pass_bin1
-./run_hh4b.sh --workspace --bfit --dfit --limits
-python3 PlotFitsRun2.py --fit-file cards/run2-bdt-20210712/FitShapes.root --plots-dir plots/run2-bdt-20210712/ --bin-name passbin1
-```
-
-# Unit testing postprocessing
-
-`tests/test_postprocessing_core.py` pins the behavior of the core postprocessing helpers
-(`add_bdt_scores`, the FOM functions, TXbb-SF jet selection, event counting, and the
-template utilities) with small synthetic DataFrames — no skimmer directories or parquet
-reads involved, so it runs in a couple of minutes.
-
-From the repo root:
+Current single-era production command (run from `src/HH4b/postprocessing`):
 
 ```bash
-PYTHONPATH=src python -m pytest tests/test_postprocessing_core.py -q
+nohup python3 PostProcess.py --templates-tag 26Jan15 --tag nanov15_20251202_v15_signal --mass H2PNetMass --txbb glopart-v3 --bdt-config v13_glopartv3 --bdt-model 25Feb5_v13_glopartv2_rawmass --fom-scan --data-dir /ceph/cms/store/user/zichun/bbbb/skimmer/ --no-vbf-priority --vbf --no-rerun-inference --txbb-wps 0.945 0.85 --bdt-wps 0.935 0.78 0.03 --vbf-txbb-wp 0.8 --vbf-bdt-wp 0.9825 --years 2024 --templates --no-fom-scan-bin1 --no-fom-scan-bin2 --no-fom-scan-vbf --control-plots > templates_2024.out 2>&1 &
 ```
 
-or run the full suite with `PYTHONPATH=src python -m pytest -q`.
+Equivalent (same options, multi-line for readability):
+
+```bash
+nohup python3 PostProcess.py \
+  --templates-tag 26Jan15 \
+  --tag nanov15_20251202_v15_signal \
+  --mass H2PNetMass \
+  --txbb glopart-v3 \
+  --bdt-config v13_glopartv3 \
+  --bdt-model 25Feb5_v13_glopartv2_rawmass \
+  --fom-scan \
+  --data-dir /ceph/cms/store/user/zichun/bbbb/skimmer/ \
+  --no-vbf-priority \
+  --vbf \
+  --no-rerun-inference \
+  --txbb-wps 0.945 0.85 \
+  --bdt-wps 0.935 0.78 0.03 \
+  --vbf-txbb-wp 0.8 \
+  --vbf-bdt-wp 0.9825 \
+  --years 2024 \
+  --templates \
+  --no-fom-scan-bin1 \
+  --no-fom-scan-bin2 \
+  --no-fom-scan-vbf \
+  --control-plots \
+  > templates_2024.out 2>&1 &
+```
+
+### What the script does (high level)
+
+`PostProcess.py` executes the following flow:
+
+- Parses runtime configuration (`--years`, `--txbb`, `--bdt-model`, WPs, booleans like `--templates`, `--control-plots`, `--fom-scan`).
+- Loads events per year/process via `load_process_run3_samples()`.
+- Runs or loads BDT inference outputs and applies region/category selections.
+- Builds control plots and optional FOM scans.
+- Builds histogram templates (including jec/jmsr shifts) and saves them.
+
+### Key outputs
+
+Given `--templates-tag <TAG>`:
+
+- Control/FOM plots: `plots/PostProcess/<TAG>/...`
+- Template files: `templates/<TAG>/<YEAR>_templates.pkl`
+- Cutflows: `templates/<TAG>/cutflows/preselection_cutflow_<YEAR>.csv`
+- Runtime args snapshot: `templates/<TAG>/args.txt`
+
+### Batch processing
+
+For multi-era production, pass several eras to `--years` (e.g. `--years 2022 2022EE`)
+or launch one `nohup ... > templates_<YEAR>.out` job per era as in the example above.
+
+## 2) Unit testing postprocessing
+
+### Goal
+
+Catch regressions in selector naming, year configuration, and orchestration logic without heavy IO.
+
+### Test files
+
+The current lightweight test suite is:
+
+- `tests/test_selectors.py`
+  - `check_selector()` behavior for exact (`?`), prefix, and contains (`*`) matching.
+- `tests/test_postprocessing_core.py`
+  - `add_bdt_scores` discriminants, FOM functions, TXbb-SF jet selection, and
+    template utilities on small synthetic DataFrames.
+- `tests/test_xsec_resolution.py`
+  - `_resolve_xsec_key()` alias/case-insensitive fallback behavior.
+- `tests/test_hhvars_contracts.py`
+  - year/sample/lumi configuration contracts (including 2024/2025-related guards).
+- `tests/test_postprocessing_load_run3_samples.py`
+  - monkeypatched `load_run3_samples()` orchestration test, no real parquet reads.
+
+### How these tests stay fast
+
+- no real skimmer directory scans
+- no parquet reads
+- no heavy template creation
+- monkeypatching of `utils.load_samples` for orchestration coverage
+
+### Run tests
+
+From repo root:
+
+```bash
+PYTHONPATH=src python -m pytest tests/test_selectors.py tests/test_postprocessing_core.py tests/test_xsec_resolution.py tests/test_hhvars_contracts.py tests/test_postprocessing_load_run3_samples.py -q
+```
+
+If you want the full test suite:
+
+```bash
+PYTHONPATH=src python -m pytest -q
+```
+
+### Environment note
+
+Some tests intentionally use dependency guards (`pytest.importorskip(...)`) so they skip cleanly in minimal environments.
+In the standard analysis environment (with `hist`, `pandas`, etc. installed), those tests execute normally.
+
+## Practical debugging tips
+
+- If a background is unexpectedly empty, verify `hh_vars.samples_run3[year]` includes that background key and selectors match on-disk naming for that era.
+- For per-era failures, inspect `src/HH4b/postprocessing/templates_<YEAR>.out` first.
+- When adding new eras, keep `hh_vars.years`, `samples_run3`, `LUMI`, and postprocessing HLT/correction fallbacks consistent.

--- a/src/HH4b/postprocessing/datacardHelpers.py
+++ b/src/HH4b/postprocessing/datacardHelpers.py
@@ -97,18 +97,34 @@ def rem_neg(template_dict: dict):
     return template_dict
 
 
-def sum_templates(template_dict: dict, years: list[str]):
-    """Sum templates across years"""
+def _reorder_hist_to_match(h: Hist, ref: Hist) -> Hist:
+    """Reorder h's sample axis to match ref for addition compatibility.
+    Different years may have different sample order (e.g. qcd/data swapped)."""
+    ref_samples = list(ref.axes[0])
+    if list(h.axes[0]) == ref_samples:
+        return h
+    storage = ref.storage_type() if callable(ref.storage_type) else ref.storage_type
+    new_hist = Hist(
+        hist.axis.StrCategory(ref_samples, name=ref.axes[0].name),
+        *ref.axes[1:],
+        storage=storage,
+    )
+    for sample in ref_samples:
+        if sample in h.axes[0]:
+            new_hist[sample, ...] = h[sample, ...].view(flow=True)
+    return new_hist
 
-    ttemplate = next(iter(template_dict.values()))  # sample templates from which to extract values
+
+def sum_templates(template_dict: dict, years: list[str]):
+    """Sum templates across years. Handles different sample axis order across years."""
+
+    ttemplate = next(iter(template_dict.values()))
+    ref_year = years[0]
     combined = {}
 
     for region in ttemplate:
-        thists = []
-
-        for year in years:
-            thists.append(template_dict[year][region])
-
+        ref_hist = template_dict[ref_year][region]
+        thists = [_reorder_hist_to_match(template_dict[year][region], ref_hist) for year in years]
         combined[region] = sum(thists)
 
     return combined

--- a/src/HH4b/postprocessing/postprocessing.py
+++ b/src/HH4b/postprocessing/postprocessing.py
@@ -688,7 +688,7 @@ def combine_run3_samples(
         else:
             combined = pd.concat(
                 [
-                    events_dict_years[year][key].copy()
+                    events_dict_years[year][key]
                     for year in scale_processes[key]
                     if year in years_run3
                 ]
@@ -875,7 +875,9 @@ def get_templates(
         sig_events = {}
         for sig_key in sig_keys:
             if sig_key in events_dict:
-                sig_events[sig_key] = deepcopy(events_dict[sig_key][sel[sig_key]])
+                # Boolean indexing already returns a new DataFrame; deepcopy is redundant
+                # and would recursively copy all underlying numpy arrays.
+                sig_events[sig_key] = events_dict[sig_key][sel[sig_key]]
 
         # set up samples
         if all_hist_samples is not None:

--- a/src/HH4b/utils.py
+++ b/src/HH4b/utils.py
@@ -391,27 +391,22 @@ def load_samples(
                 continue
 
             logger.debug(f"Loading {sample}")
+
             try:
                 non_empty_passed_list = []
                 for parquet_file in parquet_path.glob("*.parquet"):
-                    if not pd.read_parquet(parquet_file).empty:
-                        df_sample = pd.read_parquet(
-                            parquet_file, filters=filters, columns=load_columns
-                        )
+                    # Read with column projection and filters upfront; check empty afterwards.
+                    # Previously the file was read twice: once with no args to test emptiness,
+                    # then again with columns/filters — doubling I/O per file.
+                    df_sample = pd.read_parquet(parquet_file, filters=filters, columns=load_columns)
+                    if not df_sample.empty:
                         non_empty_passed_list.append(df_sample)
                 events = pd.concat(non_empty_passed_list, ignore_index=True)
-            except Exception:
+            except Exception as e:
+                logger.error(f"Error loading {sample}: {e}")
                 warnings.warn(
                     f"Can't read file with requested columns/filters for {sample}!", stacklevel=1
                 )
-                non_empty_passed_list = []
-                for parquet_file in parquet_path.glob("*.parquet"):
-                    if not pd.read_parquet(parquet_file).empty:
-                        df_sample = pd.read_parquet(
-                            parquet_file, filters=filters, columns=load_columns
-                        )
-                        non_empty_passed_list.append(df_sample)
-                events = pd.concat(non_empty_passed_list, ignore_index=True)
                 continue
 
             # no events?


### PR DESCRIPTION
The README rewrite, adapted per your decisions: run_templates_queue.sh reference replaced with generic batch guidance (script stays local), example updated to --bdt-config v13_glopartv3, test list updated. .gitignore gains CMSSW/rhalphalib/PID/log entries (upstream's test-fixture exceptions kept)