### PR TITLE
Fix 2025 template normalization in the 2024 MC 50/50 split

### DIFF
--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -8,7 +8,7 @@ import pprint
 import sys
 from collections import OrderedDict
 from pathlib import Path
-from typing import Callable
+from typing import Callable, NamedTuple
 
 import awkward as ak
 import hist
@@ -493,6 +493,67 @@ def calculate_txbb_weights(
     return txbb_sf_weight
 
 
+# TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+class MCSplitConfig(NamedTuple):
+    """How one year's MC is drawn from a (possibly shared) source sample."""
+
+    source_year: str  # year whose MC is read from disk
+    split_half: int | None  # parity half to keep; None keeps every event
+    weight_scale: float  # factor applied to the MC weight columns
+
+
+# TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+def get_mc_split_config(year: str, split_shared_mc: bool = False) -> MCSplitConfig:
+    """Resolve which MC a year is built from, and how its weights must be rescaled.
+
+    2025 has no MC of its own. With ``split_shared_mc`` it is built from the 2024 sample,
+    split 50/50 by event parity so that the 2024 and 2025 templates stay statistically
+    independent when they enter the same fit. Each half is scaled by 2 to recover the full
+    2024 yield, and 2025 is then rescaled to its own luminosity.
+
+    Without ``split_shared_mc``, 2024 uses its full sample and 2025 cannot be built at all.
+    """
+    if year == "2025":
+        if not split_shared_mc:
+            raise ValueError(
+                "2025 has no MC of its own. Pass --split-shared-mc to build the 2025 "
+                "templates from half of the 2024 MC (2024 then uses the other half), "
+                "or drop 2025 from --years."
+            )
+        source_year = "2024"
+        target_lumi = hh_vars.LUMI.get(year)
+        if target_lumi is None:
+            target_lumi = sum(v for k, v in hh_vars.LUMI.items() if k.startswith("2025"))
+        # x2 recovers the full 2024 yield from the half we keep; the luminosity ratio then
+        # rescales those 2024-normalized weights to 2025.
+        return MCSplitConfig(source_year, 1, 2.0 * target_lumi / hh_vars.LUMI[source_year])
+
+    if year == "2024" and split_shared_mc:
+        # half the events are reserved for 2025, so x2 recovers the full 2024 yield
+        return MCSplitConfig(year, 0, 2.0)
+
+    return MCSplitConfig(year, None, 1.0)
+
+
+# TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+def mc_split_mask(run, luminosity_block, event, split_half: int) -> np.ndarray:
+    """Deterministic 50/50 partition of MC events by (run + lumi + event) parity.
+
+    Each field is reduced mod 2 before summing, so the arithmetic stays in range for the
+    skimmer's dtypes (run/lumi uint32, event uint64) with no cast at all. Non-integer ids
+    are rejected rather than coerced: event numbers run past 2**53, so a float column has
+    already lost exactly the low bit this depends on, and splitting on it would silently
+    produce a wrong -- but entirely plausible-looking -- partition.
+    """
+    parity = 0
+    for name, raw in (("run", run), ("luminosityBlock", luminosity_block), ("event", event)):
+        ids = np.asarray(raw)
+        if not np.issubdtype(ids.dtype, np.integer):
+            raise TypeError(f"{name} must have an integer dtype for the MC split, got {ids.dtype}")
+        parity = parity + (ids % 2)
+    return parity % 2 == split_half
+
+
 def load_process_run3_samples(
     args,
     year,
@@ -602,28 +663,17 @@ def load_process_run3_samples(
     # define cutflows
     samples_year = list(samples_run3[year].keys())
 
-    # MC fallback and luminosity scaling for years without dedicated MC (e.g. 2025).
-    # We split 2024 MC 50/50: half for 2024 templates, half for 2025 templates.
-    # Split is deterministic via (run + luminosityBlock + event) % 2.
-    mc_fallback_year = None
-    mc_lumi_scale = 1.0
-    mc_split_half = None  # 0 = use for 2024, 1 = use for 2025
-    if year == "2025":
-        # 2025 has no MC: use 2024 MC (other half), scale yields to 2025 lumi.
-        mc_fallback_year = "2024"
-        target_lumi = hh_vars.LUMI.get(year)
-        if target_lumi is None:
-            target_lumi = sum(v for k, v in hh_vars.LUMI.items() if k.startswith("2025"))
-        # LUMI SCALING: MC weights are norm'd to source-year lumi; multiply by target/source
-        # to get yields appropriate for 2025.
-        mc_lumi_scale = target_lumi / hh_vars.LUMI[mc_fallback_year]
-        mc_split_half = 1  # use events with (run+lumi+evt)%2 == 1
+    # TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+    # 2025 has no dedicated MC; under --split-shared-mc it is built from half of the 2024
+    # sample, with 2024 taking the other half. Data always comes from the year itself.
+    # getattr: overlap/eventlist.py and Scaling_Toys.py build their own args without
+    # this flag. They never build 2025, so defaulting to no sharing preserves their
+    # behaviour exactly (full 2024 MC, weights untouched).
+    mc_split = get_mc_split_config(year, split_shared_mc=getattr(args, "split_shared_mc", False))
+    if mc_split.source_year != year:
         samples_year = [hh_vars.data_key] + [
-            k for k in samples_run3[mc_fallback_year] if k != hh_vars.data_key
+            k for k in samples_run3[mc_split.source_year] if k != hh_vars.data_key
         ]
-    elif year == "2024":
-        # Use half of 2024 MC for 2024 templates; the other half is reserved for 2025.
-        mc_split_half = 0  # use events with (run+lumi+evt)%2 == 0
 
     if not control_plots and not args.bdt_roc and "qcd" in samples_year:
         samples_year.remove("qcd")
@@ -646,8 +696,8 @@ def load_process_run3_samples(
         logger.info(f"Load samples {key}")
 
         source_year = year
-        if mc_fallback_year is not None and key != hh_vars.data_key:
-            source_year = mc_fallback_year
+        if mc_split.source_year != year and key != hh_vars.data_key:
+            source_year = mc_split.source_year
 
         samples_to_process = {source_year: {key: samples_run3[source_year][key]}}
 
@@ -674,19 +724,20 @@ def load_process_run3_samples(
             continue
         events_dict = _loaded[key]
 
-        # --- 2024 MC split: use half for 2024, half for 2025 (deterministic) --- (from main)
-        if mc_split_half is not None and key != hh_vars.data_key:
-            run_ = events_dict["run"].to_numpy().squeeze()
-            lumi_ = events_dict["luminosityBlock"].to_numpy().squeeze()
-            evt_ = events_dict["event"].to_numpy().squeeze()
-            # Avoid overflow: (a+b+c)%2 = (a%2 + b%2 + c%2)%2
-            mask = ((run_ % 2) + (lumi_ % 2) + (evt_ % 2)) % 2 == mc_split_half
-            events_dict = events_dict.loc[mask].copy()
+        # TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+        # Keep this year's half of the shared 2024 sample, then rescale its weights: x2 to
+        # recover the full 2024 yield from the half we kept, and for 2025 the 2024->2025
+        # luminosity ratio on top. Both factors are folded into weight_scale.
+        if mc_split.split_half is not None and key != hh_vars.data_key:
+            events_dict = events_dict.loc[
+                mc_split_mask(
+                    events_dict["run"].to_numpy().squeeze(),
+                    events_dict["luminosityBlock"].to_numpy().squeeze(),
+                    events_dict["event"].to_numpy().squeeze(),
+                    mc_split.split_half,
+                )
+            ].copy()
 
-            # We keep half the events; scale weights by 2 so the total weighted yield matches
-            # the FULL source-year MC. This applies to BOTH the 2024 half and the 2025 half --
-            # for 2025 the LUMI SCALING block below then rescales 2024->2025 lumi. (Previously
-            # the x2 was applied only to 2024, leaving the 2025 templates at half normalization.)
             weight_cols = [
                 col
                 for col in events_dict.columns.get_level_values(0).unique()
@@ -694,19 +745,7 @@ def load_process_run3_samples(
                 or (col.startswith("weight_") and "noxsec" not in col and "nonorm" not in col)
             ]
             for col in weight_cols:
-                events_dict[col] = events_dict[col] * 2.0
-
-        # --- LUMI SCALING (2025): MC from fallback year (2024) is norm'd to 2024 lumi;
-        # scale weights by LUMI_2025/LUMI_2024 so yields match 2025 lumi. ---
-        if mc_fallback_year is not None and key != hh_vars.data_key:
-            weight_cols = []
-            for col in events_dict.columns.get_level_values(0).unique():
-                if col in {"weight", "finalWeight", "scale_weights", "pdf_weights"} or (
-                    col.startswith("weight_") and ("noxsec" not in col and "nonorm" not in col)
-                ):
-                    weight_cols.append(col)
-            for col in weight_cols:
-                events_dict[col] = events_dict[col] * mc_lumi_scale
+                events_dict[col] = events_dict[col] * mc_split.weight_scale
 
         # inference and assign score
         jshifts = [""]
@@ -2636,6 +2675,17 @@ if __name__ == "__main__":
         type=str,
         default="event_lists",
         help="folder to save the event list for each year",
+    )
+    # TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+    run_utils.add_bool_arg(
+        parser,
+        "split-shared-mc",
+        default=False,
+        help=(
+            "split the 2024 MC 50/50 between the 2024 and 2025 templates. Required to "
+            "build 2025, which has no MC of its own. Needed whenever 2024 and 2025 will "
+            "be combined in the same fit, so that their MC statistics stay independent"
+        ),
     )
     run_utils.add_bool_arg(parser, "bdt-roc", default=False, help="make BDT ROC curve")
     run_utils.add_bool_arg(parser, "control-plots", default=False, help="make control plots")

--- a/src/HH4b/postprocessing/PostProcess.py
+++ b/src/HH4b/postprocessing/PostProcess.py
@@ -633,17 +633,18 @@ def load_process_run3_samples(
             mask = ((run_ % 2) + (lumi_ % 2) + (evt_ % 2)) % 2 == mc_split_half
             events_dict = events_dict.loc[mask].copy()
 
-            # LUMI SCALING (2024): we keep half the events; scale weights by 2 so that
-            # the total weighted yield matches full 2024 MC (i.e. full 2024 lumi).
-            if year == "2024":
-                weight_cols = [
-                    col
-                    for col in events_dict.columns.get_level_values(0).unique()
-                    if col in {"weight", "finalWeight", "scale_weights", "pdf_weights"}
-                    or (col.startswith("weight_") and "noxsec" not in col and "nonorm" not in col)
-                ]
-                for col in weight_cols:
-                    events_dict[col] = events_dict[col] * 2.0
+            # We keep half the events; scale weights by 2 so the total weighted yield matches
+            # the FULL source-year MC. This applies to BOTH the 2024 half and the 2025 half --
+            # for 2025 the LUMI SCALING block below then rescales 2024->2025 lumi. (Previously
+            # the x2 was applied only to 2024, leaving the 2025 templates at half normalization.)
+            weight_cols = [
+                col
+                for col in events_dict.columns.get_level_values(0).unique()
+                if col in {"weight", "finalWeight", "scale_weights", "pdf_weights"}
+                or (col.startswith("weight_") and "noxsec" not in col and "nonorm" not in col)
+            ]
+            for col in weight_cols:
+                events_dict[col] = events_dict[col] * 2.0
 
         # --- LUMI SCALING (2025): MC from fallback year (2024) is norm'd to 2024 lumi;
         # scale weights by LUMI_2025/LUMI_2024 so yields match 2025 lumi. ---

--- a/tests/test_mc_split_scaling.py
+++ b/tests/test_mc_split_scaling.py
@@ -119,16 +119,6 @@ class TestMCSplitMask:
         with pytest.raises(TypeError, match="integer"):
             pp.mc_split_mask(ids, ids, ids, 0)
 
-    def test_split_mask_handles_large_event_numbers(self):
-        """Event numbers exceed 2**53, so a float64 code path would lose the parity."""
-        run = np.array([1, 1], dtype=np.int64)
-        lumi = np.array([1, 1], dtype=np.int64)
-        event = np.array([2**62 - 1, 2**62], dtype=np.int64)  # odd, even
-        # (1 + 1 + odd) % 2 == 1 ; (1 + 1 + even) % 2 == 0
-        np.testing.assert_array_equal(
-            pp.mc_split_mask(run, lumi, event, 1), np.array([True, False])
-        )
-
 
 class TestSplitClosure:
     """Config and mask together must reproduce the full sample's yield."""

--- a/tests/test_mc_split_scaling.py
+++ b/tests/test_mc_split_scaling.py
@@ -1,0 +1,156 @@
+"""Tests for sharing the 2024 MC between the 2024 and 2025 templates.
+
+TEMPORARY(mc-sharing) -- delete once 2025 has MC of its own.
+
+2025 has no dedicated MC, so under ``--split-shared-mc`` the 2024 sample is split 50/50 by
+event parity: half builds the 2024 templates, half the 2025 templates, each scaled back up
+to its year's luminosity. Keeping the halves disjoint is what lets the two years enter the
+same fit without their MC statistical uncertainties being correlated.
+
+When 2025 MC exists, ``grep -rn "TEMPORARY(mc-sharing)"`` lists every site to remove:
+this file, the two helpers in PostProcess, the CLI flag, and its call site.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("hist")
+pytest.importorskip("mplhep")
+pytest.importorskip("xgboost")
+
+from HH4b import hh_vars
+from HH4b.postprocessing import PostProcess as pp
+
+# Read from hh_vars rather than hardcoded: 2025 is still accumulating luminosity, so a
+# pinned ratio would turn a routine LUMI update into a test failure.
+LUMI_RATIO = hh_vars.LUMI["2025"] / hh_vars.LUMI["2024"]
+
+STANDARD_YEARS = ["2022", "2022EE", "2023", "2023BPix"]
+
+
+class TestMCSplitConfig:
+    """The (year, --split-shared-mc) -> (source MC, half, weight scale) table."""
+
+    @pytest.mark.parametrize("split_shared_mc", [False, True])
+    def test_standard_years_never_split_or_rescale(self, split_shared_mc):
+        """Years with their own MC are untouched, and the flag must not reach them."""
+        for year in STANDARD_YEARS:
+            cfg = pp.get_mc_split_config(year, split_shared_mc=split_shared_mc)
+            assert cfg.source_year == year
+            assert cfg.split_half is None
+            assert cfg.weight_scale == 1.0
+
+    def test_2024_without_sharing_uses_full_mc(self):
+        """Default: nothing is reserved for 2025, so 2024 keeps every event at face value."""
+        cfg = pp.get_mc_split_config("2024", split_shared_mc=False)
+        assert cfg.source_year == "2024"
+        assert cfg.split_half is None
+        assert cfg.weight_scale == 1.0
+
+    def test_2024_with_sharing_takes_half_and_compensates(self):
+        """Sharing on: 2024 keeps parity half 0, x2 to recover the full 2024 yield."""
+        cfg = pp.get_mc_split_config("2024", split_shared_mc=True)
+        assert cfg.source_year == "2024"
+        assert cfg.split_half == 0
+        assert cfg.weight_scale == pytest.approx(2.0)
+
+    def test_2025_with_sharing_takes_other_half_and_rescales_to_2025_lumi(self):
+        """Sharing on: 2025 keeps parity half 1, x2 for the split and x lumi ratio for the year.
+
+        The x2 is the factor that was missing before: without it the 2025 templates came out
+        at exactly half their correct normalization.
+        """
+        cfg = pp.get_mc_split_config("2025", split_shared_mc=True)
+        assert cfg.source_year == "2024"
+        assert cfg.split_half == 1
+        assert cfg.weight_scale == pytest.approx(2.0 * LUMI_RATIO)
+        # guard against a regression to the un-compensated value
+        assert cfg.weight_scale != pytest.approx(LUMI_RATIO)
+
+    def test_2025_without_sharing_is_an_error(self):
+        """There is no 2025 MC. Refusing to run beats silently inventing a normalization."""
+        with pytest.raises(ValueError, match="split-shared-mc"):
+            pp.get_mc_split_config("2025", split_shared_mc=False)
+
+    def test_2025_lumi_falls_back_to_sum_of_sub_eras(self, monkeypatch):
+        """If LUMI has no aggregate '2025' key, the sub-era luminosities are summed."""
+        lumi = {k: v for k, v in hh_vars.LUMI.items() if k != "2025"}
+        monkeypatch.setattr(hh_vars, "LUMI", lumi)
+        expected = sum(v for k, v in lumi.items() if k.startswith("2025"))
+        cfg = pp.get_mc_split_config("2025", split_shared_mc=True)
+        assert cfg.weight_scale == pytest.approx(2.0 * expected / lumi["2024"])
+
+
+class TestMCSplitMask:
+    """The parity mask that assigns each event to exactly one of the two years."""
+
+    @staticmethod
+    def _event_ids(n=10_000, seed=0):
+        rng = np.random.default_rng(seed)
+        return (
+            rng.integers(1, 400_000, size=n, dtype=np.int64),
+            rng.integers(1, 3_000, size=n, dtype=np.int64),
+            rng.integers(1, 2**40, size=n, dtype=np.int64),
+        )
+
+    def test_split_mask_is_a_partition(self):
+        """Every event lands in exactly one half: disjoint and covering."""
+        run, lumi, event = self._event_ids()
+        half_0 = pp.mc_split_mask(run, lumi, event, 0)
+        half_1 = pp.mc_split_mask(run, lumi, event, 1)
+        assert not np.any(half_0 & half_1), "an event was assigned to both years"
+        assert np.all(half_0 | half_1), "an event was assigned to neither year"
+
+    def test_split_mask_accepts_skimmer_dtypes(self):
+        """The skimmer writes run/lumi as uint32 and event as uint64; no cast may be needed."""
+        run = np.array([1, 2], dtype=np.uint32)
+        lumi = np.array([3, 4], dtype=np.uint32)
+        event = np.array([2**63 + 1, 2**63 + 2], dtype=np.uint64)  # odd, even
+        # (1 + 3 + odd) % 2 == 1 ; (2 + 4 + even) % 2 == 0
+        np.testing.assert_array_equal(
+            pp.mc_split_mask(run, lumi, event, 1), np.array([True, False])
+        )
+
+    def test_split_mask_rejects_non_integer_ids(self):
+        """A float column cannot represent these event numbers; fail loudly, never guess."""
+        ids = np.array([1.0, 2.0])
+        with pytest.raises(TypeError, match="integer"):
+            pp.mc_split_mask(ids, ids, ids, 0)
+
+    def test_split_mask_handles_large_event_numbers(self):
+        """Event numbers exceed 2**53, so a float64 code path would lose the parity."""
+        run = np.array([1, 1], dtype=np.int64)
+        lumi = np.array([1, 1], dtype=np.int64)
+        event = np.array([2**62 - 1, 2**62], dtype=np.int64)  # odd, even
+        # (1 + 1 + odd) % 2 == 1 ; (1 + 1 + even) % 2 == 0
+        np.testing.assert_array_equal(
+            pp.mc_split_mask(run, lumi, event, 1), np.array([True, False])
+        )
+
+
+class TestSplitClosure:
+    """Config and mask together must reproduce the full sample's yield."""
+
+    def test_split_halves_close_to_the_full_sample_yield(self):
+        """Constructed with an exactly even split, so this is an identity, not a statistic."""
+        n = 10_000
+        run = np.zeros(n, dtype=np.int64)
+        lumi = np.zeros(n, dtype=np.int64)
+        event = np.arange(n, dtype=np.int64)  # alternating parity -> exactly half each
+        weights = np.ones(n)
+
+        cfg_2024 = pp.get_mc_split_config("2024", split_shared_mc=True)
+        cfg_2025 = pp.get_mc_split_config("2025", split_shared_mc=True)
+        half_2024 = pp.mc_split_mask(run, lumi, event, cfg_2024.split_half)
+        half_2025 = pp.mc_split_mask(run, lumi, event, cfg_2025.split_half)
+
+        total = weights.sum()
+        # unscaled, the halves partition the sample exactly
+        assert weights[half_2024].sum() + weights[half_2025].sum() == total
+        # rescaled, 2024 recovers the full 2024 yield and 2025 lands at the 2025 lumi
+        assert (weights[half_2024] * cfg_2024.weight_scale).sum() == pytest.approx(total)
+        assert (weights[half_2025] * cfg_2025.weight_scale).sum() == pytest.approx(
+            total * LUMI_RATIO
+        )


### PR DESCRIPTION
2024 and 2025 share the 2024 MC (there is no dedicated 2025 MC): the sample is split 50/50 by (run + luminosityBlock + event) % 2, each half scaled by 2 to recover the full source-year yield, then rescaled to the target year's luminosity.

The x2 compensation for keeping only half the events was guarded by `if year == "2024"`, so the 2025 half never received it. The net weight factor for 2025 was 0.5 * LUMI_2025/LUMI_2024 instead of LUMI_2025/LUMI_2024, i.e. the 2025 templates came out at exactly half their correct normalization. Apply the x2 to both split halves.